### PR TITLE
[CLEANUP] Remove dividers2tabs TCA option

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
@@ -5,8 +5,7 @@ return [
         'label' => '{domainObject.listModuleValueLabel}',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,<f:if condition="{domainObject.sorting}">
+        'cruser_id' => 'cruser_id',<f:if condition="{domainObject.sorting}">
         'sortby' => 'sorting',</f:if>
 <f:if condition="{extension.supportVersioning}">		'versioningWS' => 2,
         'versioning_followPages' => true,</f:if>

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
@@ -6,7 +6,6 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,
 
         'versioningWS' => 2,
         'versioning_followPages' => true,

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
@@ -6,7 +6,6 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,
         'versioningWS' => 2,
         'versioning_followPages' => true,
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
@@ -6,7 +6,6 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,
         'versioningWS' => 2,
         'versioning_followPages' => true,
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
@@ -6,7 +6,6 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,
         'versioningWS' => 2,
         'versioning_followPages' => true,
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
@@ -6,7 +6,6 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
-        'dividers2tabs' => 1,
         'sortby' => 'sorting',
         'versioningWS' => 2,
         'versioning_followPages' => true,


### PR DESCRIPTION
The option was removed from Core with 7.0 already.

Releases: master, 7.6