### PR TITLE
[BUGFIX] Prevent using wrong configurationManager implementation.

### DIFF
--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 /**
  * Load settings from yaml file and from TYPO3_CONF_VARS extConf
  */
-class ConfigurationManager extends \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
+class ExtensionBuilderConfigurationManager extends \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
 {
     /**
      * @var string

--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -14,13 +14,13 @@ namespace EBT\ExtensionBuilder\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
 use EBT\ExtensionBuilder\Domain\Repository\ExtensionRepository;
 use EBT\ExtensionBuilder\Domain\Validator\ExtensionValidator;
 use EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder;
 use EBT\ExtensionBuilder\Service\RoundTrip;
 use EBT\ExtensionBuilder\Utility\ExtensionInstallationStatus;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -36,7 +36,7 @@ class BuilderModuleController extends ActionController
      */
     protected $fileGenerator = null;
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -75,10 +75,10 @@ class BuilderModuleController extends ActionController
     }
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
         $this->settings = $this->configurationManager->getSettings();

--- a/Classes/Domain/Repository/ExtensionRepository.php
+++ b/Classes/Domain/Repository/ExtensionRepository.php
@@ -20,15 +20,15 @@ namespace EBT\ExtensionBuilder\Domain\Repository;
 class ExtensionRepository implements \TYPO3\CMS\Core\SingletonInterface
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }
@@ -75,6 +75,6 @@ class ExtensionRepository implements \TYPO3\CMS\Core\SingletonInterface
         if (defined('JSON_PRETTY_PRINT')) {
             $encodeOptions |= JSON_PRETTY_PRINT;
         }
-        \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile($extension->getExtensionDir() . \EBT\ExtensionBuilder\Configuration\ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE, json_encode($extensionBuildConfiguration, $encodeOptions));
+        \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile($extension->getExtensionDir() . \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE, json_encode($extensionBuildConfiguration, $encodeOptions));
     }
 }

--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -14,7 +14,7 @@ namespace EBT\ExtensionBuilder\Domain\Validator;
  * The TYPO3 project - inspiring people to share!
  */
 
-use EBT\ExtensionBuilder\Configuration\ConfigurationManager;
+use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
 use EBT\ExtensionBuilder\Domain\Exception\ExtensionException;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\Relation\AbstractRelation;
 use EBT\ExtensionBuilder\Service\ValidationService;
@@ -153,7 +153,7 @@ class ExtensionValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
      */
     const ERROR_MAPPING_TO_INCOMPATIBLE_TABLE = 606;
     /**
-     * @var ConfigurationManager
+     * @var ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -164,10 +164,10 @@ class ExtensionValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
     protected $warningsToIgnore = array();
 
     /**
-     * @param ConfigurationManager $configurationManager
+     * @param ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }
@@ -224,7 +224,7 @@ class ExtensionValidator extends \TYPO3\CMS\Extbase\Validation\Validator\Abstrac
     {
         if (is_dir($extension->getExtensionDir())) {
             $settingsFile = $extension->getExtensionDir() .
-                ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
+                ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
             if (!file_exists($settingsFile) || $extension->isRenamed()) {
                 $this->validationResult['warnings'][] = new ExtensionException(
                     'Extension directory exists',

--- a/Classes/Service/ClassBuilder.php
+++ b/Classes/Service/ClassBuilder.php
@@ -61,7 +61,7 @@ class ClassBuilder implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected $printerService = null;
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -78,10 +78,10 @@ class ClassBuilder implements \TYPO3\CMS\Core\SingletonInterface
     protected $extensionDirectory = '';
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }

--- a/Classes/Service/ExtensionSchemaBuilder.php
+++ b/Classes/Service/ExtensionSchemaBuilder.php
@@ -20,15 +20,15 @@ namespace EBT\ExtensionBuilder\Service;
 class ExtensionSchemaBuilder implements \TYPO3\CMS\Core\SingletonInterface
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }

--- a/Classes/Service/ObjectSchemaBuilder.php
+++ b/Classes/Service/ObjectSchemaBuilder.php
@@ -22,7 +22,7 @@ use EBT\ExtensionBuilder\Utility\Tools;
 class ObjectSchemaBuilder implements \TYPO3\CMS\Core\SingletonInterface
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -31,10 +31,10 @@ class ObjectSchemaBuilder implements \TYPO3\CMS\Core\SingletonInterface
     protected $relatedForeignTables = array();
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }

--- a/Classes/Service/RoundTrip.php
+++ b/Classes/Service/RoundTrip.php
@@ -14,7 +14,7 @@ namespace EBT\ExtensionBuilder\Service;
  * The TYPO3 project - inspiring people to share!
  */
 
-use EBT\ExtensionBuilder\Configuration\ConfigurationManager;
+use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
 use EBT\ExtensionBuilder\Domain\Model;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\Relation\AbstractRelation;
 use EBT\ExtensionBuilder\Utility\Inflector;
@@ -74,7 +74,7 @@ class RoundTrip implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected $parserService = null;
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      * @inject
      *
      */
@@ -130,11 +130,11 @@ class RoundTrip implements \TYPO3\CMS\Core\SingletonInterface
         if (file_exists($this->previousExtensionDirectory . 'kickstarter.json')) {
             rename(
                 $this->previousExtensionDirectory . 'kickstarter.json',
-                $this->previousExtensionDirectory . ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE
+                $this->previousExtensionDirectory . ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE
             );
         }
 
-        if (file_exists($this->previousExtensionDirectory . ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE)) {
+        if (file_exists($this->previousExtensionDirectory . ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE)) {
             $extensionSchemaBuilder = GeneralUtility::makeInstance('EBT\\ExtensionBuilder\\Service\\ExtensionSchemaBuilder');
             $jsonConfig = $this->configurationManager->getExtensionBuilderConfiguration($this->previousExtensionKey);
             GeneralUtility::devLog(
@@ -1015,7 +1015,7 @@ class RoundTrip implements \TYPO3\CMS\Core\SingletonInterface
                 }
             }
             if (file_exists($extension->getExtensionDir() . 'Configuration/TCA/' . $domainObject->getName() . '.php')) {
-                $extensionConfigurationJson = \EBT\ExtensionBuilder\Configuration\ConfigurationManager::getExtensionBuilderJson($extension->getExtensionKey());
+                $extensionConfigurationJson = \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::getExtensionBuilderJson($extension->getExtensionKey());
                 if (floatval($extensionConfigurationJson['log']['extension_builder_version']) <= 6.2) {
                     self::moveAdditionalTcaToOverrideFile($domainObject);
                 }

--- a/Classes/ViewHelpers/MappingViewHelper.php
+++ b/Classes/ViewHelpers/MappingViewHelper.php
@@ -19,15 +19,15 @@ use EBT\ExtensionBuilder\Domain\Model\DomainObject;
 class MappingViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }

--- a/Classes/ViewHelpers/RecordTypeViewHelper.php
+++ b/Classes/ViewHelpers/RecordTypeViewHelper.php
@@ -20,15 +20,15 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
 class RecordTypeViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
 
     /**
-     * @param \EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager
+     * @param \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager
      * @return void
      */
-    public function injectConfigurationManager(\EBT\ExtensionBuilder\Configuration\ConfigurationManager $configurationManager)
+    public function injectExtensionBuilderConfigurationManager(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager $configurationManager)
     {
         $this->configurationManager = $configurationManager;
     }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -2,6 +2,6 @@
 return [
     'ExtensionBuilder::wiringEditorSmdEndpoint' => [
         'path' => '/extensionBuilder/wireEditor',
-        'target' => EBT\ExtensionBuilder\Configuration\ConfigurationManager::class . '::getWiringEditorSmd'
+        'target' => EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::class . '::getWiringEditorSmd'
     ],
 ];

--- a/Tests/BaseFunctionalTest.php
+++ b/Tests/BaseFunctionalTest.php
@@ -101,7 +101,7 @@ abstract class BaseFunctionalTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCa
         $this->extension->setSettings($settings);
 
         // get instances to inject in Mocks
-        $configurationManager = $this->objectManager->get(\EBT\ExtensionBuilder\Configuration\ConfigurationManager::class);
+        $configurationManager = $this->objectManager->get(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::class);
 
         $this->parserService = new \EBT\ExtensionBuilder\Service\Parser(new \PhpParser\Lexer());
         $this->printerService = $this->objectManager->get(\EBT\ExtensionBuilder\Service\Printer::class);

--- a/Tests/Functional/CompatibilityTest.php
+++ b/Tests/Functional/CompatibilityTest.php
@@ -29,7 +29,7 @@ use org\bovigo\vfs\vfsStream;
 class CompatibilityTest extends \EBT\ExtensionBuilder\Tests\BaseFunctionalTest
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -61,7 +61,7 @@ class CompatibilityTest extends \EBT\ExtensionBuilder\Tests\BaseFunctionalTest
         $this->extensionSchemaBuilder = $this->objectManager->get('EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder');
 
         $testExtensionDir = $this->fixturesPath . 'TestExtensions/test_extension/';
-        $jsonFile = $testExtensionDir . \EBT\ExtensionBuilder\Configuration\ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
+        $jsonFile = $testExtensionDir . \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
 
         if (file_exists($jsonFile)) {
             // compatibility adaptions for configurations from older versions

--- a/Tests/Functional/CompatibilityTest.php
+++ b/Tests/Functional/CompatibilityTest.php
@@ -55,7 +55,7 @@ class CompatibilityTest extends \EBT\ExtensionBuilder\Tests\BaseFunctionalTest
     public function generateExtensionFromVersion3Configuration()
     {
         $this->configurationManager = $this->getAccessibleMock(
-            'EBT\ExtensionBuilder\Configuration\ConfigurationManager',
+            'EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager',
             array('dummy')
         );
         $this->extensionSchemaBuilder = $this->objectManager->get('EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder');

--- a/Tests/Functional/ConfigurationManagerTest.php
+++ b/Tests/Functional/ConfigurationManagerTest.php
@@ -17,14 +17,14 @@ namespace EBT\ExtensionBuilder\Tests\Unit;
 class ConfigurationManagerTest extends \EBT\ExtensionBuilder\Tests\BaseFunctionalTest
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager;
 
     protected function setUp()
     {
         parent::setUp();
-        $this->configurationManager = $this->objectManager->get('EBT\\ExtensionBuilder\\Configuration\\ConfigurationManager');
+        $this->configurationManager = $this->objectManager->get('EBT\\ExtensionBuilder\\Configuration\\ExtensionBuilderConfigManager');
     }
 
     /**

--- a/Tests/Functional/ConfigurationManagerTest.php
+++ b/Tests/Functional/ConfigurationManagerTest.php
@@ -24,7 +24,7 @@ class ConfigurationManagerTest extends \EBT\ExtensionBuilder\Tests\BaseFunctiona
     protected function setUp()
     {
         parent::setUp();
-        $this->configurationManager = $this->objectManager->get('EBT\\ExtensionBuilder\\Configuration\\ExtensionBuilderConfigManager');
+        $this->configurationManager = $this->objectManager->get('EBT\\ExtensionBuilder\\Configuration\\ExtensionBuilderConfigurationManager');
     }
 
     /**

--- a/Tests/Functional/RoundTripRenameVendorTest.php
+++ b/Tests/Functional/RoundTripRenameVendorTest.php
@@ -39,7 +39,7 @@ class RoundTripRenameVendorTest extends \EBT\ExtensionBuilder\Tests\BaseFunction
         $this->extensionSchemaBuilder = $this->objectManager->get('EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder');
 
         $testExtensionDir = $this->fixturesPath . 'TestExtensions/test_extension/';
-        $jsonFile = $testExtensionDir . \EBT\ExtensionBuilder\Configuration\ConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
+        $jsonFile = $testExtensionDir . \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::EXTENSION_BUILDER_SETTINGS_FILE;
 
         if (file_exists($jsonFile)) {
             // compatibility adaptions for configurations from older versions

--- a/Tests/Functional/RoundTripRenameVendorTest.php
+++ b/Tests/Functional/RoundTripRenameVendorTest.php
@@ -33,7 +33,7 @@ class RoundTripRenameVendorTest extends \EBT\ExtensionBuilder\Tests\BaseFunction
     {
         parent::setUp();
         $this->configurationManager = $this->getAccessibleMock(
-            'EBT\ExtensionBuilder\Configuration\ConfigurationManager',
+            'EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager',
             array('dummy')
         );
         $this->extensionSchemaBuilder = $this->objectManager->get('EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder');

--- a/Tests/Unit/ClassBuilderTest.php
+++ b/Tests/Unit/ClassBuilderTest.php
@@ -40,7 +40,7 @@ class ClassBuilderTest extends \EBT\ExtensionBuilder\Tests\BaseUnitTest
         $printerService = $this->getAccessibleMock(\EBT\ExtensionBuilder\Service\Printer::class, array('dummy'));
         $nodeFactory = new \EBT\ExtensionBuilder\Parser\NodeFactory();
         $printerService->_set('nodeFactory', $nodeFactory);
-        $configurationManager = new \EBT\ExtensionBuilder\Configuration\ConfigurationManager();
+        $configurationManager = new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager();
         $this->classBuilder->_set('parserService', $parserService);
         $this->classBuilder->_set('printerService', $printerService);
         $this->classBuilder->_set('configurationManager', $configurationManager);

--- a/Tests/Unit/ExtensionSchemaBuilderTest.php
+++ b/Tests/Unit/ExtensionSchemaBuilderTest.php
@@ -30,10 +30,10 @@ class ExtensionSchemaBuilderTest extends \EBT\ExtensionBuilder\Tests\BaseUnitTes
         parent::setUp();
         $this->extension = $this->getMock(\EBT\ExtensionBuilder\Domain\Model\Extension::class, array('getOverWriteSettings'));
         $this->extensionSchemaBuilder = $this->getAccessibleMock(\EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder::class, array('dummy'));
-        $this->extensionSchemaBuilder->injectConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ConfigurationManager());
+        $this->extensionSchemaBuilder->injectExtensionBuilderConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager());
         /** @var $objectSchemaBuilder \EBT\ExtensionBuilder\Service\ObjectSchemaBuilder */
         $objectSchemaBuilder = $this->getAccessibleMock(\EBT\ExtensionBuilder\Service\ObjectSchemaBuilder::class, array('dummy'));
-        $objectSchemaBuilder->injectConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ConfigurationManager());
+        $objectSchemaBuilder->injectConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager());
         $this->extensionSchemaBuilder->injectObjectSchemaBuilder($objectSchemaBuilder);
         $this->extensionKey = 'dummy';
     }

--- a/Tests/Unit/ExtensionSchemaBuilderTest.php
+++ b/Tests/Unit/ExtensionSchemaBuilderTest.php
@@ -33,7 +33,7 @@ class ExtensionSchemaBuilderTest extends \EBT\ExtensionBuilder\Tests\BaseUnitTes
         $this->extensionSchemaBuilder->injectExtensionBuilderConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager());
         /** @var $objectSchemaBuilder \EBT\ExtensionBuilder\Service\ObjectSchemaBuilder */
         $objectSchemaBuilder = $this->getAccessibleMock(\EBT\ExtensionBuilder\Service\ObjectSchemaBuilder::class, array('dummy'));
-        $objectSchemaBuilder->injectConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager());
+        $objectSchemaBuilder->injectExtensionBuilderConfigurationManager(new \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager());
         $this->extensionSchemaBuilder->injectObjectSchemaBuilder($objectSchemaBuilder);
         $this->extensionKey = 'dummy';
     }

--- a/Tests/Unit/ObjectSchemaBuilderTest.php
+++ b/Tests/Unit/ObjectSchemaBuilderTest.php
@@ -17,7 +17,7 @@ namespace EBT\ExtensionBuilder\Tests\Unit;
 class ObjectSchemaBuilderTest extends \EBT\ExtensionBuilder\Tests\BaseUnitTest
 {
     /**
-     * @var \EBT\ExtensionBuilder\Configuration\ConfigurationManager
+     * @var \EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager
      */
     protected $configurationManager = null;
     /**
@@ -32,9 +32,9 @@ class ObjectSchemaBuilderTest extends \EBT\ExtensionBuilder\Tests\BaseUnitTest
         $concreteConfigurationManager = $this->getAccessibleMock(\TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager::class);
         $typoScriptService = new \TYPO3\CMS\Extbase\Service\TypoScriptService();
         $concreteConfigurationManager->_set('typoScriptService', $typoScriptService);
-        $this->configurationManager = $this->getAccessibleMock(\EBT\ExtensionBuilder\Configuration\ConfigurationManager::class, array('getExtbaseClassConfiguration'));
+        $this->configurationManager = $this->getAccessibleMock(\EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager::class, array('getExtbaseClassConfiguration'));
         $this->configurationManager->_set('concreteConfigurationManager', $concreteConfigurationManager);
-        $this->objectSchemaBuilder->injectConfigurationManager($this->configurationManager);
+        $this->objectSchemaBuilder->injectExtensionBuilderConfigurationManager($this->configurationManager);
     }
 
     /**

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,7 +1,4 @@
  # global configuration
-config.tx_extbase.objects {
-	TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface.className = EBT\ExtensionBuilder\Configuration\ConfigurationManager
-}
 module.extension_builder {
 	settings{
 		codeTemplateRootPath = EXT:extension_builder/Resources/Private/CodeTemplates/Extbase/


### PR DESCRIPTION
# [BUGFIX] Prevent using wrong configurationManager implementation.
(different approch of fixing it then BenjaminBeck).
Rename ConfigurationManager to ExtensionBuilderConfigurationManager. Not let ExtensionBuilders ConfigurationManager be injected outside. That cause conflicts with flux extension.