### PR TITLE
[BUGFIX] Create valid composer.json

### DIFF
--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -894,7 +894,7 @@ class Extension
         $info = [
             'name' => strtolower($this->vendorName) . '/' . strtolower(str_replace('_','-',$this->extensionKey)), 'type' => 'typo3-cms-extension',
             'description' => $this->description,
-            'author' => [], 'require' => [
+            'authors' => [], 'require' => [
                 'typo3/cms-core' => '^8.6.1'
             ],
             'autoload' => [
@@ -910,10 +910,7 @@ class Extension
             if ($person->getRole() !== '') {
                 $author['role'] = $person->getRole();
             }
-            if ($person->getCompany() !== '') {
-                $author['company'] = $person->getCompany();
-            }
-            $info['author'][] = $author;
+            $info['authors'][] = $author;
         }
         return $info;
     }


### PR DESCRIPTION
The author information is stored in an array authors (plural) not author.

The composer.json scheme is very strict and does not allow additional properties for the authors property. Therefore the company entry is removed for each author.

`$ composer validate` is now passed.