### PR TITLE
[BUGFIX] Fix MySQL `date DEFAULT '0000-00-00'` issues

### DIFF
--- a/Classes/Domain/Model/DomainObject/NativeDateProperty.php
+++ b/Classes/Domain/Model/DomainObject/NativeDateProperty.php
@@ -35,7 +35,7 @@ class NativeDateProperty extends AbstractProperty
 
     public function getSqlDefinition()
     {
-        return $this->getFieldName() . " date DEFAULT '0000-00-00',";
+        return $this->getFieldName() . " date DEFAULT NULL,";
     }
 
     public function getNameToBeDisplayedInFluidTemplate()

--- a/Classes/Domain/Model/DomainObject/NativeDateTimeProperty.php
+++ b/Classes/Domain/Model/DomainObject/NativeDateTimeProperty.php
@@ -35,7 +35,7 @@ class NativeDateTimeProperty extends AbstractProperty
 
     public function getSqlDefinition()
     {
-        return $this->getFieldName() . " datetime DEFAULT '0000-00-00 00:00:00',";
+        return $this->getFieldName() . " datetime DEFAULT NULL,";
     }
 
     public function getNameToBeDisplayedInFluidTemplate()

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/NativeDateProperty.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/NativeDateProperty.phpt
@@ -4,5 +4,5 @@
     'renderType' => 'inputDateTime',
     'size' => 7,
     'eval' => 'date<f:if condition="{property.required}">,required</f:if>',
-    'default' => '0000-00-00'
+    'default' => null,
 ],

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/NativeDateTimeProperty.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/NativeDateTimeProperty.phpt
@@ -4,5 +4,5 @@
     'renderType' => 'inputDateTime',
     'size' => 12,
     'eval' => 'datetime<f:if condition="{property.required}">,required</f:if>',
-    'default' => '0000-00-00 00:00:00'
+    'default' => null,
 ],

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
@@ -134,7 +134,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'size' => 7,
                 'eval' => 'date',
-                'default' => '0000-00-00'
+                'default' => null,
             ],
         ],
         'date_property2' => [
@@ -146,7 +146,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'size' => 12,
                 'eval' => 'datetime',
-                'default' => '0000-00-00 00:00:00'
+                'default' => null,
             ],
         ],
         'date_property3' => [

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
@@ -163,7 +163,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'size' => 7,
                 'eval' => 'date',
-                'default' => '0000-00-00'
+                'default' => null,
             ],
 
         ],

--- a/Tests/Fixtures/TestExtensions/test_extension/ext_tables.sql
+++ b/Tests/Fixtures/TestExtensions/test_extension/ext_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE tx_testextension_domain_model_main (
 	name varchar(255) DEFAULT '' NOT NULL,
 	identifier varchar(255) DEFAULT '' NOT NULL,
 	description text,
-	my_date date DEFAULT '0000-00-00',
+	my_date date DEFAULT NULL,
 	child1 int(11) unsigned DEFAULT '0',
 	children2 int(11) unsigned DEFAULT '0' NOT NULL,
 	child3 int(11) unsigned DEFAULT '0',
@@ -99,8 +99,8 @@ CREATE TABLE tx_testextension_domain_model_child2 (
 	main int(11) unsigned DEFAULT '0' NOT NULL,
 
 	name varchar(255) DEFAULT '' NOT NULL,
-	date_property1 date DEFAULT '0000-00-00',
-	date_property2 datetime DEFAULT '0000-00-00 00:00:00',
+	date_property1 date DEFAULT NULL,
+	date_property2 datetime DEFAULT NULL,
 	date_property3 int(11) DEFAULT '0' NOT NULL,
 	date_property4 int(11) DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
The used default value for date types `0000-00-00` might lead to errors
using MySQL 5.7 which uses `NO_ZERO_DATE` in `sql_mode` per default.
To solve this issue the default value is defined to be `NULL`.

see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date

Fixes: #113 