### PR TITLE
Add a warning comment and a link concerning the usage persistence.storagePid

### DIFF
--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TypoScript/setup.ts
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TypoScript/setup.ts
@@ -9,6 +9,9 @@ plugin.tx_testextension_testplugin {
         layoutRootPaths.1 = {$plugin.tx_testextension_testplugin.view.layoutRootPath}
     }
     persistence {
+        # Be aware that a manual storage assignment via "Record Storage Page" in the
+        # backend will not have any effect once a storagePid is set via TypoScript.
+        # See https://forge.typo3.org/issues/58857
         storagePid = {$plugin.tx_testextension_testplugin.persistence.storagePid}
         #recursive = 1
     }


### PR DESCRIPTION
Once persistence.storagePid is set, the manual assignment of a "Record Storage Folder" in the Backend won't have any effect anymore. 
This is confusing, because a simple extension having "Record Storage Folder" assigned manually in the BE, can work work out of the box. But as soon as the automatically generated TypoScript is incorporated, no records are shown any more  - because as soon as there is a Typoscript "persistence.storagePid =" [empty] is assigned.