### PR TITLE
Update deprecated locallang-reference

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
@@ -79,7 +79,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],


### PR DESCRIPTION
Updated locallang_core - filereference ("There is a reference to "EXT:lang/locallang_core.xlf", which has been moved to "EXT:lang/Resources/Private/Language/locallang_core.xlf". This fallback will be removed with TYPO3 v9.").