### PR TITLE
Update deprecated locallang_core - filereference

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/BooleanProperty.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/BooleanProperty.phpt
@@ -2,7 +2,7 @@
     'type' => 'check',
     'items' => [
         '1' => [
-            '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+            '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
         ]
     ],
     'default' => 0,


### PR DESCRIPTION
Updated file-reference to locallang_core, since current version is deprecated.
(There is a reference to "EXT:lang/locallang_core.xlf", which has been moved to "EXT:lang/Resources/Private/Language/locallang_core.xlf". This fallback will be removed with TYPO3 v9.)