### PR TITLE
Update deprecated references to EXT:lang/locallang_core.xlf

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
@@ -79,7 +79,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/BooleanProperty.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/BooleanProperty.phpt
@@ -2,7 +2,7 @@
     'type' => 'check',
     'items' => [
         '1' => [
-            '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+            '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
         ]
     ],
     'default' => 0,

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
@@ -78,7 +78,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],
@@ -131,7 +131,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
                 'default' => 0,

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
@@ -78,7 +78,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
@@ -78,7 +78,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
@@ -78,7 +78,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
@@ -79,7 +79,7 @@ return [
                 'type' => 'check',
                 'items' => [
                     '1' => [
-                        '0' => 'LLL:EXT:lang/locallang_core.xlf:labels.enabled'
+                        '0' => 'LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.enabled'
                     ]
                 ],
             ],


### PR DESCRIPTION
Replace deprecated references to locallang_core 
(EXT:lang/locallang_core.xlf => EXT:lang/Resources/Private/Language/locallang_core.xlf)
in 8.7-branch to get rid of deprecation-warnings.