### PR TITLE
Use ".typoscript" instead of ".ts" for TypoScript files

### DIFF
--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -1263,7 +1263,6 @@ class FileGenerator
 
             if ($overWriteMode == 1 && strpos($targetFile, 'Classes') === false) {
                 // classes are merged by the class builder
-                $fileExtension = strtolower(pathinfo($targetFile, PATHINFO_EXTENSION));
                 if ($fileExtension == 'html') {
                     //TODO: We need some kind of protocol to be displayed after code generation
                     return;

--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -116,7 +116,8 @@ class FileGenerator
         'php', //ext_tables, localconf
         'sql',
         'txt', // Typoscript
-        'ts' // Typoscript
+        'ts', // Typoscript
+        'typoscript', // Typoscript
     ];
     /**
      * @var \EBT\ExtensionBuilder\Service\LocalizationService
@@ -481,7 +482,7 @@ class FileGenerator
                 $this->mkdir_deep($this->extensionDirectory, 'Configuration/TypoScript');
                 $typoscriptDirectory = $this->extensionDirectory . 'Configuration/TypoScript/';
                 $fileContents = $this->generateTyposcriptSetup();
-                $this->writeFile($typoscriptDirectory . 'setup.ts', $fileContents);
+                $this->writeFile($typoscriptDirectory . 'setup.typoscript', $fileContents);
             } catch (\Exception $e) {
                 throw new \Exception('Could not generate typoscript setup, error: ' . $e->getMessage());
             }
@@ -490,7 +491,7 @@ class FileGenerator
             try {
                 $typoscriptDirectory = $this->extensionDirectory . 'Configuration/TypoScript/';
                 $fileContents = $this->generateTyposcriptConstants();
-                $this->writeFile($typoscriptDirectory . 'constants.ts', $fileContents);
+                $this->writeFile($typoscriptDirectory . 'constants.typoscript', $fileContents);
             } catch (\Exception $e) {
                 throw new \Exception('Could not generate typoscript constants, error: ' . $e->getMessage());
             }
@@ -500,7 +501,7 @@ class FileGenerator
         try {
             if ($this->extension->getDomainObjectsThatNeedMappingStatements()) {
                 $fileContents = $this->generateStaticTyposcript();
-                $this->writeFile($this->extensionDirectory . 'ext_typoscript_setup.txt', $fileContents);
+                $this->writeFile($this->extensionDirectory . 'ext_typoscript_setup.typoscript', $fileContents);
             }
         } catch (\Exception $e) {
             throw new \Exception('Could not generate static typoscript, error: ' . $e->getMessage());

--- a/Tests/Functional/FileGeneratorTest.php
+++ b/Tests/Functional/FileGeneratorTest.php
@@ -409,10 +409,6 @@ class FileGeneratorTest extends BaseFunctionalTest
     }
 
     /**
-     * @depends writeModelClassWithManyToManyRelation
-     * @depends writeAggregateRootClassesFromDomainObject
-     *
-     *
      * @test
      */
     public function writeExtensionFiles()
@@ -450,10 +446,42 @@ class FileGeneratorTest extends BaseFunctionalTest
 
         self::assertFileExists($extensionDir . 'Configuration/TCA/' . $domainObject->getDatabaseTableName() . '.php');
         self::assertFileExists($extensionDir . 'Configuration/ExtensionBuilder/settings.yaml');
+        self::assertFileExists($extensionDir . 'Configuration/TypoScript/setup.typoscript');
+        self::assertFileExists($extensionDir . 'Configuration/TypoScript/constants.typoscript');
 
         self::assertFileExists($extensionDir . 'Resources/Private/Language/locallang_db.xlf');
         self::assertFileExists($extensionDir . 'Resources/Private/Language/locallang.xlf');
         self::assertFileExists($extensionDir . 'Resources/Private/Partials/' . $domainObject->getName() . '/Properties.html');
         self::assertFileExists($extensionDir . 'Resources/Private/Partials/' . $domainObject->getName() . '/FormFields.html');
+    }
+
+    public function getDeprecatedTypoScriptExtensions()
+    {
+        return [["ts"], ["txt"]];
+    }
+
+    /**
+     * @test
+     * @dataProvider getDeprecatedTypoScriptExtensions
+     * @param $deprecatedExtension
+     */
+    public function writeExtensionFilesOverWritesFilesWithDeprecatedExtensions($deprecatedExtension)
+    {
+        $plugin = new Plugin();
+        $plugin->setName('Test');
+        $plugin->setKey('test');
+        $this->extension->addPlugin($plugin);
+
+        $setupFile = join(DIRECTORY_SEPARATOR, [$this->extension->getExtensionDir(), 'Configuration', 'TypoScript', 'setup.' . $deprecatedExtension]);
+
+        GeneralUtility::mkdir_deep(dirname($setupFile));
+        GeneralUtility::writeFile($setupFile, "# some sample content");
+
+        $this->fileGenerator->build($this->extension);
+
+        $extensionDir = $this->extension->getExtensionDir();
+
+        self::assertFileExists($extensionDir . 'Configuration/TypoScript/setup.' . $deprecatedExtension);
+        self::assertFileNotExists($extensionDir . 'Configuration/TypoScript/setup.typoscript');
     }
 }


### PR DESCRIPTION
Fixes #189

This PR changes the default file extension for TypoScript files from ".ts" to ".typoscript" as per the [Core recommendation](https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.7.x/Feature-78161-IntroduceTypoScriptFileExtension.html).

In order to not break existing extensions when they are edited with the Extension Builder, the `FileGenerator` will give precedence to existing `.ts` files if they are present.