### PR TITLE
Fixed round-trip error for method without `@return` tag

### DIFF
--- a/Classes/Service/RoundTrip.php
+++ b/Classes/Service/RoundTrip.php
@@ -801,8 +801,7 @@ class RoundTrip implements SingletonInterface
             $mergedMethod->setTag('param', $parameterTags);
         }
 
-        $returnTagValue = $mergedMethod->getTagValue('return');
-        if ($returnTagValue != 'void') {
+        if ($mergedMethod->isTaggedWith('return') && $mergedMethod->getTagValue('return') != 'void') {
             $mergedMethod->setTag('return', $newProperty->getTypeForComment() . ' ' . $newProperty->getName());
         }
 


### PR DESCRIPTION
When you change a property with a getter and setter method, where the setter method does not have a @return-Tag, you'll get an exception while saving in round-trip mode.

Fixed #216