### PR TITLE
[FEATURE] Allow persisting to composer storage paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,6 +28,10 @@ indent_size = 3
 [*.{yaml,yml}]
 indent_size = 2
 
+# HTML files
+[*.html]
+indent_style = tab
+
 # package.json
 # .travis.yml
 [{package.json,.travis.yml}]

--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -85,6 +85,7 @@ class ExtensionBuilderConfigurationManager extends ConfigurationManager
         $extensionConfigurationJson = json_decode($this->inputData['params']['working'], true);
         $extensionConfigurationJson = $this->reArrangeRelations($extensionConfigurationJson);
         $extensionConfigurationJson['modules'] = $this->checkForAbsoluteClassNames($extensionConfigurationJson['modules']);
+        $extensionConfigurationJson['storagePath'] = $this->inputData['params']['storagePath'] ?? null;
         return $extensionConfigurationJson;
     }
 
@@ -154,12 +155,13 @@ class ExtensionBuilderConfigurationManager extends ConfigurationManager
      * Reads the stored configuration (i.e. the extension model etc.).
      *
      * @param string $extensionKey
+     * @param string|null $storagePath
      * @return array|null
      */
-    public function getExtensionBuilderConfiguration($extensionKey)
+    public function getExtensionBuilderConfiguration($extensionKey, $storagePath = null)
     {
         $result = null;
-        $extensionConfigurationJson = self::getExtensionBuilderJson($extensionKey);
+        $extensionConfigurationJson = self::getExtensionBuilderJson($extensionKey, $storagePath);
         if ($extensionConfigurationJson) {
             $extensionConfigurationJson = $this->fixExtensionBuilderJSON($extensionConfigurationJson);
             $extensionConfigurationJson['properties']['originalExtensionKey'] = $extensionKey;
@@ -170,9 +172,15 @@ class ExtensionBuilderConfigurationManager extends ConfigurationManager
         return $result;
     }
 
-    public static function getExtensionBuilderJson($extensionKey)
+    /**
+     * @param string $extensionKey
+     * @param string|null $storagePath
+     * @return mixed|null
+     */
+    public static function getExtensionBuilderJson($extensionKey, $storagePath = null)
     {
-        $jsonFile = PATH_typo3conf . 'ext/' . $extensionKey . '/' . self::EXTENSION_BUILDER_SETTINGS_FILE;
+        $storagePath = $storagePath ?? PATH_typo3conf . 'ext/';
+        $jsonFile = $storagePath . $extensionKey . '/' . self::EXTENSION_BUILDER_SETTINGS_FILE;
         if (file_exists($jsonFile)) {
             return json_decode(file_get_contents($jsonFile), true);
         } else {

--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -284,7 +284,6 @@ class BuilderModuleController extends ActionController
 
         if (!$extensionExistedBefore) {
             GeneralUtility::mkdir($extensionDirectory);
-            $extensionExistedBefore = false;
         }
         if ($usesComposerPath && !is_link($publicExtensionDirectory)) {
             symlink(

--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -20,9 +20,11 @@ use EBT\ExtensionBuilder\Domain\Exception\ExtensionException;
 use EBT\ExtensionBuilder\Domain\Repository\ExtensionRepository;
 use EBT\ExtensionBuilder\Domain\Validator\ExtensionValidator;
 use EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder;
+use EBT\ExtensionBuilder\Service\ExtensionService;
 use EBT\ExtensionBuilder\Service\FileGenerator;
 use EBT\ExtensionBuilder\Service\RoundTrip;
 use EBT\ExtensionBuilder\Utility\ExtensionInstallationStatus;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -55,6 +57,11 @@ class BuilderModuleController extends ActionController
      * @var \EBT\ExtensionBuilder\Service\ExtensionSchemaBuilder
      */
     protected $extensionSchemaBuilder = null;
+
+    /**
+     * @var ExtensionService
+     */
+    protected $extensionService;
 
     /**
      * @var \EBT\ExtensionBuilder\Domain\Validator\ExtensionValidator
@@ -114,6 +121,14 @@ class BuilderModuleController extends ActionController
     public function injectExtensionSchemaBuilder(ExtensionSchemaBuilder $extensionSchemaBuilder)
     {
         $this->extensionSchemaBuilder = $extensionSchemaBuilder;
+    }
+
+    /**
+     * @param ExtensionService $extensionService
+     */
+    public function injectExtensionService(ExtensionService $extensionService)
+    {
+        $this->extensionService = $extensionService;
     }
 
     /**
@@ -179,6 +194,7 @@ class BuilderModuleController extends ActionController
             PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('extension_builder')));
         $this->view->assign('settings', $this->extensionBuilderConfigurationManager->getSettings());
         $this->view->assign('currentAction', $this->request->getControllerActionName());
+        $this->view->assign('storagePaths', $this->extensionService->resolveStoragePaths());
         $this->getBackendUserAuthentication()->pushModuleData('extensionbuilder', ['firstTime' => 0]);
     }
 
@@ -262,10 +278,22 @@ class BuilderModuleController extends ActionController
         }
 
         $extensionDirectory = $extension->getExtensionDir();
+        $publicExtensionDirectory = Environment::getExtensionsPath() . '/' . $extension->getExtensionKey();
+        $usesComposerPath = $this->extensionService->isComposerStoragePath($extensionDirectory);
+        $extensionExistedBefore = is_dir($extensionDirectory);
 
-        if (!is_dir($extensionDirectory)) {
+        if (!$extensionExistedBefore) {
             GeneralUtility::mkdir($extensionDirectory);
-        } else {
+            $extensionExistedBefore = false;
+        }
+        if ($usesComposerPath && !is_link($publicExtensionDirectory)) {
+            symlink(
+                PathUtility::getRelativePath(dirname($publicExtensionDirectory), $extensionDirectory),
+                $publicExtensionDirectory
+            );
+        }
+
+        if ($extensionExistedBefore) {
             if ($this->extensionBuilderSettings['extConf']['backupExtension'] === '1') {
                 try {
                     RoundTrip::backupExtension($extension, $this->extensionBuilderSettings['extConf']['backupDir']);
@@ -278,8 +306,10 @@ class BuilderModuleController extends ActionController
                 if (empty($extensionSettings)) {
                     // no config file in an existing extension!
                     // this would result in a	 total overwrite so we create one and give a warning
-                    $this->extensionBuilderConfigurationManager->createInitialSettingsFile($extension,
-                        $this->extensionBuilderSettings['codeTemplateRootPaths']);
+                    $this->extensionBuilderConfigurationManager->createInitialSettingsFile(
+                        $extension,
+                        $this->extensionBuilderSettings['codeTemplateRootPaths']
+                    );
                     return ['warning' => "<span class='error'>Roundtrip is enabled but no configuration file was found.</span><br />This might happen if you use the extension builder the first time for this extension. <br />A settings file was generated in <br /><b>typo3conf/ext/" . $extension->getExtensionKey() . '/Configuration/ExtensionBuilder/settings.yaml.</b><br />Configure the overwrite settings, then save again.'];
                 }
                 try {
@@ -303,11 +333,12 @@ class BuilderModuleController extends ActionController
         try {
             $this->fileGenerator->build($extension);
             $this->extensionInstallationStatus->setExtension($extension);
+            $this->extensionInstallationStatus->setUsesComposerPath($usesComposerPath);
             $message = '<p>The Extension was saved</p>' . $this->extensionInstallationStatus->getStatusMessage();
             if ($extension->getNeedsUploadFolder()) {
                 $message .= '<br />Notice: File upload is not yet implemented.';
             }
-            $result = ['success' => $message];
+            $result = ['success' => $message, 'usesComposerPath' => $usesComposerPath];
             if ($this->extensionInstallationStatus->isDbUpdateNeeded()) {
                 $result['confirmUpdate'] = true;
             }

--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -162,6 +162,11 @@ class Extension
     protected $previousExtensionKey = '';
 
     /**
+     * @var string|null
+     */
+    protected $storagePath;
+
+    /**
      * @return string
      */
     public function getExtensionKey()
@@ -227,7 +232,7 @@ class Extension
             if (empty($this->extensionKey)) {
                 throw new \Exception('ExtensionDir can only be created if an extensionKey is defined first');
             }
-            $this->extensionDir = PATH_typo3conf . 'ext/' . $this->extensionKey . '/';
+            $this->extensionDir = ($this->storagePath ?? PATH_typo3conf . 'ext/') . $this->extensionKey . '/';
         }
         return $this->extensionDir;
     }
@@ -714,6 +719,25 @@ class Extension
         } else {
             return $this->extensionDir;
         }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStoragePath(): ?string
+    {
+        return $this->storagePath;
+    }
+
+    /**
+     * @param string|null $storagePath
+     */
+    public function setStoragePath(?string $storagePath): void
+    {
+        if ($storagePath !== null) {
+            $storagePath = rtrim($storagePath, '/') . '/';
+        }
+        $this->storagePath = $storagePath;
     }
 
     /**

--- a/Classes/Service/ExtensionSchemaBuilder.php
+++ b/Classes/Service/ExtensionSchemaBuilder.php
@@ -131,6 +131,8 @@ class ExtensionSchemaBuilder implements SingletonInterface
             $this->setExtensionRelations($extensionBuildConfiguration, $extension);
         }
 
+        $extension->setStoragePath($extensionBuildConfiguration['storagePath'] ?? null);
+
         return $extension;
     }
 

--- a/Classes/Service/ExtensionService.php
+++ b/Classes/Service/ExtensionService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace EBT\ExtensionBuilder\Service;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Core\Utility\StringUtility;
+
+class ExtensionService
+{
+    /**
+     * @return string[]
+     */
+    public function resolveStoragePaths(): array
+    {
+        $storagePaths = array_merge(
+            [Environment::getExtensionsPath()],
+            $this->resolveComposerStoragePaths()
+        );
+
+        $storagePaths = array_map(
+            function (string $storagePath) {
+                return rtrim($storagePath, '/') . '/';
+            },
+            $storagePaths
+        );
+        return $storagePaths;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function resolveComposerStoragePaths(): array
+    {
+        if (!defined('TYPO3_COMPOSER_MODE') || !TYPO3_COMPOSER_MODE) {
+            return [];
+        }
+
+        $storagePaths = [];
+        $projectPath = Environment::getProjectPath();
+        $composerSettings = json_decode(file_get_contents($projectPath . '/composer.json'), true);
+        foreach ($composerSettings['repositories'] ?? [] as $repository) {
+            if (empty($repository['url']) || ($repository['type'] ?? null) !== 'path') {
+                continue;
+            }
+            // skip non-symlinked path repositories
+            if (($repository['options']['symlink'] ?? null) === false) {
+                continue;
+            }
+            if (GeneralUtility::isAbsPath($repository['url'])) {
+                $storagePaths[] = $repository['url'];
+            } else {
+                $repositoryPath = PathUtility::getCanonicalPath($projectPath . '/' . $repository['url']);
+                $storagePaths[] = preg_replace('#/[*?/]+$#', '', $repositoryPath);
+            }
+        }
+        return $storagePaths;
+    }
+
+    /**
+     * @param string $path
+     * @return bool
+     */
+    public function isComposerStoragePath(string $path): bool
+    {
+        foreach ($this->resolveComposerStoragePaths() as $composerStoragePath) {
+            if (StringUtility::beginsWith($path, $composerStoragePath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Classes/Service/ExtensionService.php
+++ b/Classes/Service/ExtensionService.php
@@ -71,14 +71,10 @@ class ExtensionService
         return $storagePaths;
     }
 
-    /**
-     * @param string $path
-     * @return bool
-     */
     public function isComposerStoragePath(string $path): bool
     {
         foreach ($this->resolveComposerStoragePaths() as $composerStoragePath) {
-            if (StringUtility::beginsWith($path, $composerStoragePath)) {
+            if (strpos($path, $composerStoragePath) === 0) {
                 return true;
             }
         }

--- a/Classes/Utility/ExtensionInstallationStatus.php
+++ b/Classes/Utility/ExtensionInstallationStatus.php
@@ -44,6 +44,11 @@ class ExtensionInstallationStatus
      */
     protected $dbUpdateNeeded = false;
 
+    /**
+     * @var bool
+     */
+    protected $usesComposerPath = false;
+
     public function __construct()
     {
         $this->installTool = GeneralUtility::makeInstance(InstallUtility::class);
@@ -55,6 +60,14 @@ class ExtensionInstallationStatus
     public function setExtension($extension)
     {
         $this->extension = $extension;
+    }
+
+    /**
+     * @param bool $usesComposerPath
+     */
+    public function setUsesComposerPath(bool $usesComposerPath): void
+    {
+        $this->usesComposerPath = $usesComposerPath;
     }
 
     /**
@@ -92,6 +105,12 @@ class ExtensionInstallationStatus
 
         if (!ExtensionManagementUtility::isLoaded($this->extension->getExtensionKey())) {
             $statusMessage .= '<p>Your Extension is not installed yet.</p>';
+            if ($this->usesComposerPath) {
+                $statusMessage .= sprintf(
+                    '<p>Execute <code>composer require %s</code> in terminal',
+                    $this->extension->getComposerInfo()['name']
+                );
+            }
         } else {
             $statusMessage .= '<br /><p>Please check the Install Tool for possible database updates!</p>';
         }

--- a/Classes/ViewHelpers/BeFuncViewHelper.php
+++ b/Classes/ViewHelpers/BeFuncViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * View helper which return input as it is

--- a/Classes/ViewHelpers/CaseViewHelper.php
+++ b/Classes/ViewHelpers/CaseViewHelper.php
@@ -15,8 +15,8 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Case view helper that is only usable within the SwitchViewHelper.
@@ -40,7 +40,7 @@ class CaseViewHelper extends AbstractViewHelper
     /**
      *
      * @return string the contents of this view helper if $value equals the expression of the surrounding switch view helper, or $default is true. otherwise an empty string
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+     * @throws Exception
      *
      * @api
      */

--- a/Classes/ViewHelpers/ClosingTagViewHelper.php
+++ b/Classes/ViewHelpers/ClosingTagViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class ClosingTagViewHelper extends AbstractViewHelper
 {

--- a/Classes/ViewHelpers/CopyrightViewHelper.php
+++ b/Classes/ViewHelpers/CopyrightViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Format the Copyright notice

--- a/Classes/ViewHelpers/CurlyBracketsViewHelper.php
+++ b/Classes/ViewHelpers/CurlyBracketsViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class CurlyBracketsViewHelper extends AbstractViewHelper
 {

--- a/Classes/ViewHelpers/Format/HtmlSpecialCharsViewHelper.php
+++ b/Classes/ViewHelpers/Format/HtmlSpecialCharsViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Wrapper for htmlspecialchars ViewHelper

--- a/Classes/ViewHelpers/Format/IndentViewHelper.php
+++ b/Classes/ViewHelpers/Format/IndentViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Indentation ViewHelper

--- a/Classes/ViewHelpers/Format/LowercaseFirstViewHelper.php
+++ b/Classes/ViewHelpers/Format/LowercaseFirstViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Wrapper for PHPs ucfirst function.

--- a/Classes/ViewHelpers/Format/QuoteStringViewHelper.php
+++ b/Classes/ViewHelpers/Format/QuoteStringViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * View helper which returns a quoted string

--- a/Classes/ViewHelpers/Format/RemoveMultipleNewlinesViewHelper.php
+++ b/Classes/ViewHelpers/Format/RemoveMultipleNewlinesViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Removes all linebreaks

--- a/Classes/ViewHelpers/Format/TrimViewHelper.php
+++ b/Classes/ViewHelpers/Format/TrimViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Wrapper for PHPs trim function.

--- a/Classes/ViewHelpers/Format/UppercaseFirstViewHelper.php
+++ b/Classes/ViewHelpers/Format/UppercaseFirstViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers\Format;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Wrapper for PHPs ucfirst function.

--- a/Classes/ViewHelpers/HumanizeViewHelper.php
+++ b/Classes/ViewHelpers/HumanizeViewHelper.php
@@ -17,7 +17,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
 
 use EBT\ExtensionBuilder\Utility\Inflector;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Makes a word in CamelCase or lower_underscore human readable

--- a/Classes/ViewHelpers/ListForeignKeyRelationsViewHelper.php
+++ b/Classes/ViewHelpers/ListForeignKeyRelationsViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  */
 
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\Relation\ZeroToManyRelation;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Indentation ViewHelper

--- a/Classes/ViewHelpers/MappingViewHelper.php
+++ b/Classes/ViewHelpers/MappingViewHelper.php
@@ -17,7 +17,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
 
 use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 class MappingViewHelper extends AbstractConditionViewHelper
 {

--- a/Classes/ViewHelpers/MatchStringViewHelper.php
+++ b/Classes/ViewHelpers/MatchStringViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * View helper to check if one string contains another string

--- a/Classes/ViewHelpers/OpeningTagViewHelper.php
+++ b/Classes/ViewHelpers/OpeningTagViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class OpeningTagViewHelper extends AbstractViewHelper
 {

--- a/Classes/ViewHelpers/PluralizeViewHelper.php
+++ b/Classes/ViewHelpers/PluralizeViewHelper.php
@@ -17,7 +17,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
 
 use EBT\ExtensionBuilder\Utility\Inflector;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Pluralize a word

--- a/Classes/ViewHelpers/PregReplaceViewHelper.php
+++ b/Classes/ViewHelpers/PregReplaceViewHelper.php
@@ -15,7 +15,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * View helper for preg_replace

--- a/Classes/ViewHelpers/RecordTypeViewHelper.php
+++ b/Classes/ViewHelpers/RecordTypeViewHelper.php
@@ -16,10 +16,8 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  */
 
 use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
-use EBT\ExtensionBuilder\Domain\Model\DomainObject;
 use EBT\ExtensionBuilder\Utility\Tools;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class RecordTypeViewHelper

--- a/Classes/ViewHelpers/SingularizeViewHelper.php
+++ b/Classes/ViewHelpers/SingularizeViewHelper.php
@@ -17,7 +17,7 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
 
 use EBT\ExtensionBuilder\Utility\Inflector;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Pluralize a word

--- a/Classes/ViewHelpers/SwitchViewHelper.php
+++ b/Classes/ViewHelpers/SwitchViewHelper.php
@@ -15,9 +15,8 @@ namespace EBT\ExtensionBuilder\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Switch view helper which can be used to render content depending on a value or expression.
@@ -44,10 +43,10 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
  *
  * @api
  */
-class SwitchViewHelper extends AbstractViewHelper implements ChildNodeAccessInterface
+class SwitchViewHelper extends AbstractViewHelper
 {
     /**
-     * An array of \TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode
+     * An array of AbstractNode items
      * @var array
      */
     protected $childNodes = [];
@@ -61,7 +60,7 @@ class SwitchViewHelper extends AbstractViewHelper implements ChildNodeAccessInte
     protected $backupBreakState = false;
 
     /**
-     * Setter for ChildNodes - as defined in ChildNodeAccessInterface
+     * Setter for ChildNodes
      *
      * @param array $childNodes Child nodes of this syntax tree node
      * @return void

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -29,6 +29,18 @@
 						<a href="#" class="btn btn-default btn-sm" title="Save extension" id="WiringEditor-saveButton-button">
 							<core:icon identifier="actions-document-save" size="small" />
 						</a>
+                        <div class="input-group input-group-sm">
+                            <span class="input-group-addon input-group-icon">
+                                <span title="Storage Path">
+                                    <core:icon identifier="files-folder" size="small" />
+                                </span>
+                            </span>
+                            <select name="storagePath" id="storagePath" class="form-control form-control-adapt">
+                                <f:for each="{storagePaths}" as="storagePath">
+                                    <option value="{storagePath}">{storagePath}</option>
+                                </f:for>
+                            </select>
+                        </div>
 					</div>
 				</div>
 				<div class="module-docheader-bar-column-right">

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -29,18 +29,18 @@
 						<a href="#" class="btn btn-default btn-sm" title="Save extension" id="WiringEditor-saveButton-button">
 							<core:icon identifier="actions-document-save" size="small" />
 						</a>
-                        <div class="input-group input-group-sm">
-                            <span class="input-group-addon input-group-icon">
-                                <span title="Storage Path">
-                                    <core:icon identifier="files-folder" size="small" />
-                                </span>
-                            </span>
-                            <select name="storagePath" id="storagePath" class="form-control form-control-adapt">
-                                <f:for each="{storagePaths}" as="storagePath">
-                                    <option value="{storagePath}">{storagePath}</option>
-                                </f:for>
-                            </select>
-                        </div>
+						<div class="input-group input-group-sm">
+							<span class="input-group-addon input-group-icon">
+								<span title="Storage Path">
+									<core:icon identifier="files-folder" size="small" />
+								</span>
+							</span>
+							<select name="storagePath" id="storagePath" class="form-control form-control-adapt">
+								<f:for each="{storagePaths}" as="storagePath">
+									<option value="{storagePath}">{storagePath}</option>
+								</f:for>
+							</select>
+						</div>
 					</div>
 				</div>
 				<div class="module-docheader-bar-column-right">

--- a/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
+++ b/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
@@ -406,6 +406,7 @@
 			this.showSpinnerPanel.show();
 			this.dataToSubmit.name = value.name;
 			this.dataToSubmit.working = JSON.stringify(value.working);
+			this.dataToSubmit.storagePath = document.querySelector('#storagePath').value;
 			this.service.saveWiring(this.dataToSubmit, {
 				success: this.saveModuleSuccess,
 				failure: this.saveModuleFailure,
@@ -658,17 +659,19 @@
 		 * @method updateLoadPanelList
 		 */
 		updateLoadPanelList: function() {
-			var list = WireIt.cn("ul");
-			if (lang.isArray(this.pipes)) {
+		  var list;
+			if (lang.isArray(this.pipes) && this.pipes.length > 0) {
+        list = WireIt.cn("ul");
 				for (var i = 0; i < this.pipes.length; i++) {
 					var module = this.pipes[i];
 
 					this.pipesByName[module.name] = module;
 
-					var li = WireIt.cn('li', null, {cursor: 'pointer'}, module.name);
+					var li = WireIt.cn('li', null, {cursor: 'pointer'}, module.name + ' (stored in <code>' + module.storagePath + '</code>)');
+					li.dataset.name = module.name;
 					Event.addListener(li, 'click', function(e, args) {
 						try {
-							this.loadPipe(Event.getTarget(e).innerHTML);
+							this.loadPipe(Event.getTarget(e).dataset.name);
 						}
 						catch(ex) {
 							console.log(ex);
@@ -676,7 +679,10 @@
 					}, this, true);
 					list.appendChild(li);
 				}
-			}
+			} else {
+			  list = document.createElement('div');
+			  list.innerText = 'No extensions found...';
+      }
 			var panelBody = Dom.get('loadPanelBody');
 			panelBody.innerHTML = "";
 			panelBody.appendChild(list);

--- a/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
+++ b/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
@@ -680,9 +680,9 @@
 					list.appendChild(li);
 				}
 			} else {
-			  list = document.createElement('div');
-			  list.innerText = 'No extensions found...';
-      }
+				list = document.createElement('div');
+				list.innerText = 'No extensions found...';
+			}
 			var panelBody = Dom.get('loadPanelBody');
 			panelBody.innerHTML = "";
 			panelBody.appendChild(list);

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     }
   ],
   "require": {
+    "ext-json": "*",
     "typo3/cms-core": "~9.5",
     "nikic/php-parser": "^4.0",
     "typo3/cms-backend": "~9.5"


### PR DESCRIPTION
![Screenshot 2019-11-19 at 01 02 35](https://user-images.githubusercontent.com/402145/69104916-2a41fc00-0a6a-11ea-847c-d6fe60c2205d.png)

* allows to persist new extensions to composer-path directory (retrieved from root composer.json repositories section `path` in case `symlink` is enabled (→ if not explicitly disabled)
* corresponding composer.json example
```
    "repositories": {
        "local": {
            "type": "path",
            "url": "packages/*"
        }
    },
```