### PR TITLE
[FEATURE] Allow different relation render types

### DIFF
--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -916,6 +916,7 @@ class Extension
             'name' => strtolower($this->vendorName) . '/' . $composerExtensionKey,
             'type' => 'typo3-cms-extension',
             'description' => $this->description,
+            'version' => $this->getVersion() ?: '1.0.0',
             'authors' => [],
             'require' => [
                 'typo3/cms-core' => '^9.5'

--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -916,7 +916,6 @@ class Extension
             'name' => strtolower($this->vendorName) . '/' . $composerExtensionKey,
             'type' => 'typo3-cms-extension',
             'description' => $this->description,
-            'version' => $this->getVersion() ?: '1.0.0',
             'authors' => [],
             'require' => [
                 'typo3/cms-core' => '^9.5'

--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -239,6 +239,8 @@ class FileGenerator
         if ($extension->getGenerateDocumentationTemplate()) {
             $this->generateDocumentationFiles();
         }
+
+        $this->generateEmptyGitRepository();
     }
 
     protected function generateYamlSettingsFile()
@@ -766,6 +768,22 @@ class FileGenerator
         $this->writeFile($this->extensionDirectory . 'Documentation.tmpl/Index.rst', $fileContents);
         $fileContents = $this->renderTemplate('Documentation.tmpl/Settings.cfgt', ['extension' => $this->extension]);
         $this->writeFile($this->extensionDirectory . 'Documentation.tmpl/Settings.cfg', $fileContents);
+    }
+
+    protected function generateEmptyGitRepository()
+    {
+        $targetDirectory = $this->extensionDirectory . '.git/';
+        if (is_file($targetDirectory) || is_dir($targetDirectory) || is_link($targetDirectory)) {
+            return;
+        }
+        $sourceDirectory = ExtensionManagementUtility::extPath('extension_builder') . 'Resources/Private/CodeTemplates/Git/';
+        $targetDirectory = $this->extensionDirectory . '.git/';
+        foreach (['objects/info', 'objects/pack', 'refs/heads', 'refs/tags'] as $item) {
+            $this->mkdir_deep($targetDirectory . $item, '');
+        }
+        foreach (['config', 'description', 'HEAD', 'info/exclude'] as $item) {
+            $this->upload_copy_move($sourceDirectory . $item, $targetDirectory . $item);
+        }
     }
 
     /**

--- a/Classes/ViewHelpers/ListForeignKeyRelationsViewHelper.php
+++ b/Classes/ViewHelpers/ListForeignKeyRelationsViewHelper.php
@@ -46,6 +46,7 @@ class ListForeignKeyRelationsViewHelper extends AbstractViewHelper
             }
             foreach ($domainObject->getProperties() as $property) {
                 if ($property instanceof ZeroToManyRelation
+                    && $property->getRenderType() === 'inline'
                     && $property->getForeignClassName() === $expectedDomainObject->getFullQualifiedClassName()
                 ) {
                     $results[] = $property;

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ManyToOneRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ManyToOneRelation.phpt
@@ -1,7 +1,26 @@
-[
+<f:switch expression="{property.renderType}"><f:case value="selectMultipleSideBySide">[
+    'type' => 'select',
+    'renderType' => '{property.renderType}',
+    'foreign_table' => '{property.foreignDatabaseTableName}',
+    'size' => 10,
+    'autoSizeMax' => 30,
+    'maxitems' => 1,
+    'multiple' => 0,
+    'fieldControl' => [
+        'editPopup' => [
+            'disabled' => false,
+        ],
+        'addRecord' => [
+            'disabled' => false,
+        ],
+        'listModule' => [
+            'disabled' => true,
+        ],
+    ],
+],</f:case><f:defaultCase>[
     'type' => 'select',
     'renderType' => 'selectSingle',
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'minitems' => 0,
     'maxitems' => 1,
-],
+],</f:defaultCase></f:switch>

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToManyRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToManyRelation.phpt
@@ -1,7 +1,27 @@
 <f:if condition="{property.type}">
     <f:then><f:comment>For files or images</f:comment>
 <f:render partial="TCA/{property.type}Property.phpt" arguments="{property: property,extension:domainObject.extension,settings:settings}" />
-    </f:then><f:else>[
+    </f:then><f:else>
+<f:switch expression="{property.renderType}"><f:case value="selectMultipleSideBySide">[
+    'type' => 'select',
+    'renderType' => '{property.renderType}',
+    'foreign_table' => '{property.foreignDatabaseTableName}',
+    'size' => 10,
+    'autoSizeMax' => 30,
+    'maxitems' => 9999,
+    'multiple' => 0,
+    'fieldControl' => [
+        'editPopup' => [
+            'disabled' => false,
+        ],
+        'addRecord' => [
+            'disabled' => false,
+        ],
+        'listModule' => [
+            'disabled' => true,
+        ],
+    ],
+],</f:case><f:defaultCase>[
     'type' => 'inline',
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'foreign_field' => '{property.foreignKeyName}',<f:if condition="{property.foreignModel.sorting}">
@@ -15,6 +35,6 @@
         'useSortable' => 1,</f:if>
         'showAllLocalizationLink' => 1
     ],
-],
+],</f:defaultCase></f:switch>
     </f:else>
 </f:if>

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToManyRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToManyRelation.phpt
@@ -1,8 +1,7 @@
 <f:if condition="{property.type}">
     <f:then><f:comment>For files or images</f:comment>
 <f:render partial="TCA/{property.type}Property.phpt" arguments="{property: property,extension:domainObject.extension,settings:settings}" />
-    </f:then><f:else>
-<f:switch expression="{property.renderType}"><f:case value="selectMultipleSideBySide">[
+    </f:then><f:else><f:switch expression="{property.renderType}"><f:case value="selectMultipleSideBySide">[
     'type' => 'select',
     'renderType' => '{property.renderType}',
     'foreign_table' => '{property.foreignDatabaseTableName}',

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
@@ -10,7 +10,7 @@
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'size' => 10,
     'autoSizeMax' => 30,
-    'maxitems' => 9999,
+    'maxitems' => 1,
     'multiple' => 0,
     'fieldControl' => [
         'editPopup' => [

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
@@ -1,15 +1,9 @@
-<f:switch expression="{property.renderType}"><f:case value="inline">[
-    'type' => 'inline',
+<f:switch expression="{property.renderType}"><f:case value="selectSingle">[
+    'type' => 'select',
+    'renderType' => 'selectSingle',
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'minitems' => 0,
     'maxitems' => 1,
-    'appearance' => [
-        'collapseAll' => 0,
-        'levelLinksPosition' => 'top',
-        'showSynchronizationLink' => 1,
-        'showPossibleLocalizationRecords' => 1,
-        'showAllLocalizationLink' => 1
-    ],
 ],</f:case><f:case value="selectMultipleSideBySide">[
     'type' => 'select',
     'renderType' => '{property.renderType}',
@@ -30,11 +24,17 @@
         ],
     ],
 ],</f:case><f:defaultCase>[
-    'type' => 'select',
-    'renderType' => 'selectSingle',
+    'type' => 'inline',
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'minitems' => 0,
     'maxitems' => 1,
+    'appearance' => [
+        'collapseAll' => 0,
+        'levelLinksPosition' => 'top',
+        'showSynchronizationLink' => 1,
+        'showPossibleLocalizationRecords' => 1,
+        'showAllLocalizationLink' => 1
+    ],
 ],</f:defaultCase></f:switch>
 
 

--- a/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/TCA/ZeroToOneRelation.phpt
@@ -1,4 +1,4 @@
-[
+<f:switch expression="{property.renderType}"><f:case value="inline">[
     'type' => 'inline',
     'foreign_table' => '{property.foreignDatabaseTableName}',
     'minitems' => 0,
@@ -10,4 +10,34 @@
         'showPossibleLocalizationRecords' => 1,
         'showAllLocalizationLink' => 1
     ],
-],
+],</f:case><f:case value="selectMultipleSideBySide">[
+    'type' => 'select',
+    'renderType' => '{property.renderType}',
+    'foreign_table' => '{property.foreignDatabaseTableName}',
+    'size' => 10,
+    'autoSizeMax' => 30,
+    'maxitems' => 9999,
+    'multiple' => 0,
+    'fieldControl' => [
+        'editPopup' => [
+            'disabled' => false,
+        ],
+        'addRecord' => [
+            'disabled' => false,
+        ],
+        'listModule' => [
+            'disabled' => true,
+        ],
+    ],
+],</f:case><f:defaultCase>[
+    'type' => 'select',
+    'renderType' => 'selectSingle',
+    'foreign_table' => '{property.foreignDatabaseTableName}',
+    'minitems' => 0,
+    'maxitems' => 1,
+],</f:defaultCase></f:switch>
+
+
+
+
+

--- a/Resources/Private/CodeTemplates/Git/HEAD
+++ b/Resources/Private/CodeTemplates/Git/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/master

--- a/Resources/Private/CodeTemplates/Git/config
+++ b/Resources/Private/CodeTemplates/Git/config
@@ -1,0 +1,6 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	precomposeunicode = true

--- a/Resources/Private/CodeTemplates/Git/config
+++ b/Resources/Private/CodeTemplates/Git/config
@@ -1,6 +1,7 @@
 [core]
 	repositoryformatversion = 0
-	filemode = true
+	filemode = false
 	bare = false
 	logallrefupdates = true
-	precomposeunicode = true
+	symlinks = false
+	ignorecase = true

--- a/Resources/Private/CodeTemplates/Git/description
+++ b/Resources/Private/CodeTemplates/Git/description
@@ -1,0 +1,1 @@
+Unnamed repository; edit this file 'description' to name the repository.

--- a/Resources/Private/CodeTemplates/Git/info/exclude
+++ b/Resources/Private/CodeTemplates/Git/info/exclude
@@ -1,0 +1,6 @@
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~

--- a/Resources/Public/jsDomainModeling/extbaseModeling.css
+++ b/Resources/Public/jsDomainModeling/extbaseModeling.css
@@ -339,11 +339,15 @@ div:hover > .deleteButton {
   display: none; }
 #domainModelEditor .inputEx-fieldWrapper.dependant {
   display: none; }
-  #domainModelEditor .inputEx-fieldWrapper.dependant.advancedMode {
-    display: none; }
+#domainModelEditor .inputEx-fieldWrapper.dependant.advancedMode {
+  display: none; }
+#domainModelEditor .relationGroup fieldset.zeroToOne .advancedSettings .inputEx-Expanded .dependant.renderType {
+  display: block; }
 #domainModelEditor .relationGroup fieldset.manyToMany .advancedSettings .inputEx-Expanded .dependant.renderType {
   display: block; }
 #domainModelEditor .relationGroup fieldset.zeroToMany .advancedSettings .inputEx-Expanded .dependant.renderType {
+  display: block; }
+#domainModelEditor .relationGroup fieldset.manyToOne .advancedSettings .inputEx-Expanded .dependant.renderType {
   display: block; }
 
 #moduleBar {

--- a/Resources/Public/jsDomainModeling/extbaseModeling.js
+++ b/Resources/Public/jsDomainModeling/extbaseModeling.js
@@ -9,7 +9,9 @@ var extbaseModeling_wiringEditorLanguage = {
 
 
 (function(){
-	var inputEx = YAHOO.inputEx, Event = YAHOO.util.Event, lang = YAHOO.lang, dom = YAHOO.util.Dom;
+		var inputEx = YAHOO.inputEx, Event = YAHOO.util.Event, lang = YAHOO.lang, dom = YAHOO.util.Dom;
+		var renderFields = inputEx.Group.prototype.renderFields;
+
 		function addFieldsetClass (selectElement) {
 			if ($(selectElement).parent().hasClass('isDependant')) {
 				return;
@@ -44,6 +46,15 @@ var extbaseModeling_wiringEditorLanguage = {
 			}
 
 		}
+
+		inputEx.Group.prototype.renderFields = function(parentEl) {
+			renderFields.call(this, parentEl);
+			var selectElements = parentEl.querySelectorAll('fieldset select[name=relationType]');
+			for (var i = 0; i < selectElements.length; i++) {
+				// trigger options rendering & enabling for relationType selectors
+				addFieldsetClass(selectElements.item(i));
+			}
+		};
 
 		inputEx.SelectField.prototype.onChange = function (evt) {
 			addFieldsetClass(evt.target);

--- a/Resources/Public/jsDomainModeling/extbaseModeling.js
+++ b/Resources/Public/jsDomainModeling/extbaseModeling.js
@@ -29,9 +29,9 @@ var extbaseModeling_wiringEditorLanguage = {
 		function updateRenderTypeOptions (selectedRelationType, renderTypeSelect) {
 			renderTypeSelect.find("option").hide();
 			var optionValueMap = {
-				'zeroToOne': ["selectSingle", "inline"],
-				'manyToOne': ["selectSingle"],
-				'zeroToMany': ["inline"],
+				'zeroToOne': ["selectSingle", "selectMultipleSideBySide", "inline"],
+				'manyToOne': ["selectSingle", "selectMultipleSideBySide"],
+				'zeroToMany': ["inline", "selectMultipleSideBySide"],
 				'manyToMany': ["selectMultipleSideBySide", "selectSingleBox", "selectCheckBox"]
 			};
 			var validOptions = optionValueMap[selectedRelationType];

--- a/Tests/Fixtures/TestExtensions/test_extension/ExtensionBuilder.json
+++ b/Tests/Fixtures/TestExtensions/test_extension/ExtensionBuilder.json
@@ -100,7 +100,7 @@
                             "relationName": "child1",
                             "relationType": "zeroToOne",
                             "relationWire": "[wired]",
-                            "renderType": "selectSingle",
+                            "renderType": "inline",
                             "uid": "894361328325"
                         },
                         {


### PR DESCRIPTION
+ 1:1: `inline` previously, existing `selectSingle` did not work
  + now it's `inline` (aggregate), `selectSingle`, `selectMultipleSideBySide`
+ *:1: `selectSingle` previously
  + now it's `selectSingle`, `selectMultipleSideBySide`
+ 1:*: `inline` previously
  + now it's `inline` (composite), `selectMultipleSideBySide`

This way it shall be possible to make use of different render types.