### PR TITLE
[BUGFIX] Ensure type inline is handled correctly

### DIFF
--- a/Classes/Domain/Model/DomainObject/Relation/AbstractRelation.php
+++ b/Classes/Domain/Model/DomainObject/Relation/AbstractRelation.php
@@ -198,8 +198,8 @@ abstract class AbstractRelation extends AbstractProperty
 
     public function getSqlDefinition()
     {
-        // store 1:n relationships as comma separated list in case TCA 'inline' is not used
-        if ($this instanceof ZeroToManyRelation && $this->renderType !== 'inline') {
+        // store 1:n relationships as comma separated list in case `select*` renderType is used
+        if ($this instanceof ZeroToManyRelation && strpos($this->renderType, 'select') === 0) {
             return $this->getFieldName() . " text NOT NULL,";
         }
         return $this->getFieldName() . " int(11) unsigned DEFAULT '0' NOT NULL,";

--- a/Classes/Service/ObjectSchemaBuilder.php
+++ b/Classes/Service/ObjectSchemaBuilder.php
@@ -196,11 +196,14 @@ class ObjectSchemaBuilder implements SingletonInterface
                 $relation->setForeignKeyName($foreignKeyName);
                 $relation->setForeignDatabaseTableName($foreignDatabaseTableName);
             }
-            if ($relation->isFileReference() && !empty($relationJsonConfiguration['maxItems'])) {
-                /** @var $relation \EBT\ExtensionBuilder\Domain\Model\DomainObject\FileProperty */
-                $relation->setMaxItems($relationJsonConfiguration['maxItems']);
-                if (!empty($relationJsonConfiguration['allowedFileTypes'])) {
-                    $relation->setAllowedFileTypes($relationJsonConfiguration['allowedFileTypes']);
+            if ($relation->isFileReference()) {
+                $relation->setRenderType('inline');
+                if (!empty($relationJsonConfiguration['maxItems'])) {
+                    /** @var $relation \EBT\ExtensionBuilder\Domain\Model\DomainObject\FileProperty */
+                    $relation->setMaxItems($relationJsonConfiguration['maxItems']);
+                    if (!empty($relationJsonConfiguration['allowedFileTypes'])) {
+                        $relation->setAllowedFileTypes($relationJsonConfiguration['allowedFileTypes']);
+                    }
                 }
             }
         }


### PR DESCRIPTION
* image properties implicitly have been treated as “inline”
* re-apply default SQL definition for 1:n relationships