### PR TITLE
Fixed ExtensionManagementUtility::extRelPath()

### DIFF
--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -117,7 +117,7 @@ class ExtensionBuilderConfigurationManager extends ConfigurationManager
         $settings = $typoscript['module.']['extension_builder.']['settings.'];
         $settings['extConf'] = $this->getExtensionBuilderSettings();
         if (empty($settings['publicResourcesPath'])) {
-            $settings['publicResourcesPath'] = ExtensionManagementUtility::siteRelPath('extension_builder') . 'Resources/Public/';
+            $settings['publicResourcesPath'] = ExtensionManagementUtility::extPath('extension_builder'). 'Resources/Public/';
         }
         return $settings;
     }

--- a/Classes/ViewHelpers/Be/ConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Be/ConfigurationViewHelper.php
@@ -33,7 +33,7 @@ class ConfigurationViewHelper extends AbstractBackendViewHelper
     {
         $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-        $baseUrl = '../' . ExtensionManagementUtility::siteRelPath('extension_builder');
+        $baseUrl = ExtensionManagementUtility::extPath('extension_builder');
         $this->pageRenderer->disableCompressJavascript();
         $this->pageRenderer->addJsFile($baseUrl . 'Resources/Public/jsDomainModeling/jquery.min.js');
         // SECTION: JAVASCRIPT FILES


### PR DESCRIPTION
Fixed the extension not loading in TYPO3 due to the removal of ExtensionManagementUtility::extRelPath()