### PR TITLE
[BUGFIX] Apply renderType to external class references

### DIFF
--- a/Classes/Service/ObjectSchemaBuilder.php
+++ b/Classes/Service/ObjectSchemaBuilder.php
@@ -174,6 +174,9 @@ class ObjectSchemaBuilder implements SingletonInterface
             $extbaseClassConfiguration = $this->configurationManager->getExtbaseClassConfiguration(
                 $relationJsonConfiguration['foreignRelationClass']
             );
+            if (!empty($relationJsonConfiguration['renderType'])) {
+                $relation->setRenderType($relationJsonConfiguration['renderType']);
+            }
             if (isset($extbaseClassConfiguration['tableName'])) {
                 $foreignDatabaseTableName = $extbaseClassConfiguration['tableName'];
             } else {


### PR DESCRIPTION
Instead of using implicit "inline" for external class references selected renderType is applied as well.