### PR TITLE
Omit vendor name when registering plugins & modules

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
@@ -6,7 +6,7 @@ call_user_func(
     {
 <f:for each="{extension.plugins}" as="plugin">
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-            '{extension.vendorName}.{extension.extensionName}',
+            '{extension.extensionName}',
             '<k:format.uppercaseFirst>{plugin.key}</k:format.uppercaseFirst>',
             [<f:if condition="{plugin.controllerActionCombinations}"><f:then>
                 <f:for each="{plugin.controllerActionCombinations}" as="actionNames" key="controllerName" iteration="j">'{controllerName}' => '<f:for each="{actionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,

--- a/Resources/Private/CodeTemplates/Extbase/extTables.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/extTables.phpt
@@ -6,7 +6,7 @@ call_user_func(
     {
 <f:for each="{extension.Plugins}" as="plugin">
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-            '{extension.vendorName}.{extension.extensionName}',
+            '{extension.extensionName}',
             '<k:format.uppercaseFirst>{plugin.key}</k:format.uppercaseFirst>',
             '<k:format.quoteString>{plugin.name}</k:format.quoteString>'
         );
@@ -20,7 +20,7 @@ call_user_func(
         if (TYPO3_MODE === 'BE') {
 <f:for each="{extension.BackendModules}" as="backendModule">
             \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-                '{extension.vendorName}.{extension.extensionName}',
+                '{extension.extensionName}',
                 '{backendModule.mainModule}', // Make module a submodule of '{backendModule.mainModule}'
                 '{backendModule.key}', // Submodule key
                 '', // Position

--- a/Tests/Fixtures/TestExtensions/test_extension/ext_localconf.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/ext_localconf.php
@@ -4,7 +4,7 @@ call_user_func(
     function()
     {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-            'FIXTURE.TestExtension',
+            'TestExtension',
             'Testplugin',
             [
                 'Main' => 'list, show, new, create, edit, update, delete'

--- a/Tests/Fixtures/TestExtensions/test_extension/ext_tables.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/ext_tables.php
@@ -6,7 +6,7 @@ call_user_func(
     {
 
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-            'FIXTURE.TestExtension',
+            'TestExtension',
             'Testplugin',
             'Test plugin'
         );
@@ -14,7 +14,7 @@ call_user_func(
         if (TYPO3_MODE === 'BE') {
 
             \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-                'FIXTURE.TestExtension',
+                'TestExtension',
                 'web', // Make module a submodule of 'web'
                 'testmodule1', // Submodule key
                 '', // Position


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.1/Deprecation-88995-CallingRegisterPluginWithVendorName.html