### PR TITLE
Update extLocalconf.phpt for using controller classes

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
@@ -9,14 +9,14 @@ call_user_func(
             '{extension.extensionName}',
             '<k:format.uppercaseFirst>{plugin.key}</k:format.uppercaseFirst>',
             [<f:if condition="{plugin.controllerActionCombinations}"><f:then>
-                <f:for each="{plugin.controllerActionCombinations}" as="actionNames" key="controllerName" iteration="j">'{controllerName}' => '<f:for each="{actionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
+                <f:for each="{plugin.controllerActionCombinations}" as="actionNames" key="controllerName" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{controllerName}Controller::class => '<f:for each="{actionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:then><f:else>
                 <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">'{domainObject.name}' => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:else></f:if>
             ],
             // non-cacheable actions
             [<f:if condition="{plugin.noncacheableControllerActions}"><f:then>
-                <f:for each="{plugin.noncacheableControllerActions}" as="noncachableActionNames" key="noncachableControllerName" iteration="j">'{noncachableControllerName}' => '<f:for each="{noncachableActionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
+                <f:for each="{plugin.noncacheableControllerActions}" as="noncachableActionNames" key="noncachableControllerName" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{noncachableControllerName}Controller::class => '<f:for each="{noncachableActionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:then><f:else>
                 <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">'{domainObject.name}' => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator"><f:if condition="{action.cacheable} == 0">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:else></f:if>


### PR DESCRIPTION
Changes in extLocalconf.phpt for creation of ext_localconf.php according to 
"Deprecation: #87550 - Use controller classes when registering plugins/modules", see:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html
I did run into this issue, when saving plugins with extension_builder 9.11.0. The registration of the controller(s) failed. With this change it now works here at least.