### PR TITLE
targetVersion/dependsOn changed to TYPO3 10.4.x

### DIFF
--- a/Resources/Public/jsDomainModeling/extensionProperties.js
+++ b/Resources/Public/jsDomainModeling/extensionProperties.js
@@ -172,12 +172,12 @@ extbaseModeling_wiringEditorLanguage.propertiesFields =
 							label: TYPO3.settings.extensionBuilder._LOCAL_LANG.target_version,
 							description: TYPO3.settings.extensionBuilder._LOCAL_LANG.descr_target_version,
 							selectOptions: [
-								'TYPO3 v 9.5'
+                'TYPO3 v 10.4'
 							],
-                            selectValues: ["9.5.0-9.5.99"],
-							value: '9.5.0-9.5.99'
-                        }
-                    },
+              selectValues: ["10.4.0-10.4.99"],
+              value: '10.4.0-10.4.99'
+						}
+					},
 					{
 						type: "text",
 						inputParams: {
@@ -187,7 +187,7 @@ extbaseModeling_wiringEditorLanguage.propertiesFields =
 							description: TYPO3.settings.extensionBuilder._LOCAL_LANG.descr_dependsOn,
 							cols:20,
 							rows:6,
-							value : "typo3 => 9.5.0-9.5.99\n"
+							value : "typo3 => 10.4.0-10.4.99\n"
 						}
 					}
 			]


### PR DESCRIPTION
set the targetVersion and dependsOn to TYPO3 10.4.x.
For targetVersion no further selectOptions/selectValues are needed (i.e. TYPO3 v 9.5) since extensions saved with the extension_builder 9.11.0 will not work in TYPO3 9.5.x anymore (caused by the changes in the plugin configuration).