### PR TITLE
Replacement of @ignorevalidation

### DIFF
--- a/Classes/Service/ClassBuilder.php
+++ b/Classes/Service/ClassBuilder.php
@@ -584,7 +584,7 @@ class ClassBuilder implements SingletonInterface
             $actionMethod->updateParamTags();
 
             if ($actionName === 'edit') {
-                $actionMethod->setTag('TYPO3\CMS\Extbase\Annotation\IgnoreValidation', '("' . $parameterName . '")' );
+                $actionMethod->setTag('TYPO3\CMS\Extbase\Annotation\IgnoreValidation' . '("' . $parameterName . '")');
             }
         }
 

--- a/Classes/Service/ClassBuilder.php
+++ b/Classes/Service/ClassBuilder.php
@@ -584,7 +584,7 @@ class ClassBuilder implements SingletonInterface
             $actionMethod->updateParamTags();
 
             if ($actionName === 'edit') {
-                $actionMethod->setTag('ignorevalidation', '$' . $parameterName);
+                $actionMethod->setTag('TYPO3\CMS\Extbase\Annotation\IgnoreValidation', '("' . $parameterName . '")' );
             }
         }
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Classes/Controller/MainController.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Classes/Controller/MainController.php
@@ -82,7 +82,7 @@ class MainController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      * action edit
      *
      * @param \FIXTURE\TestExtension\Domain\Model\Main $main
-     * @TYPO3\CMS\Extbase\Annotation\IgnoreValidation("main")
+     * @TYPO3\CMS\Extbase\Annotation\IgnoreValidation ("main")
      * @return void
      */
     public function editAction(\FIXTURE\TestExtension\Domain\Model\Main $main)

--- a/Tests/Fixtures/TestExtensions/test_extension/Classes/Controller/MainController.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Classes/Controller/MainController.php
@@ -82,7 +82,7 @@ class MainController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      * action edit
      *
      * @param \FIXTURE\TestExtension\Domain\Model\Main $main
-     * @TYPO3\CMS\Extbase\Annotation\IgnoreValidation ("main")
+     * @TYPO3\CMS\Extbase\Annotation\IgnoreValidation("main")
      * @return void
      */
     public function editAction(\FIXTURE\TestExtension\Domain\Model\Main $main)


### PR DESCRIPTION
Changes `@ignorevalidation` according to [Feature: #83094 - Replace @ignorevalidation with @TYPO3\CMS\Extbase\Annotation\IgnoreValidation](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Feature-83094-ReplaceIgnorevalidationWithTYPO3CMSExtbaseAnnotationIgnoreValidation.html).