### PR TITLE
Fix for controller registration in extLocalconf

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/extLocalconf.phpt
@@ -11,14 +11,14 @@ call_user_func(
             [<f:if condition="{plugin.controllerActionCombinations}"><f:then>
                 <f:for each="{plugin.controllerActionCombinations}" as="actionNames" key="controllerName" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{controllerName}Controller::class => '<f:for each="{actionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:then><f:else>
-                <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">'{domainObject.name}' => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
+                <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{domainObject.name}Controller::class => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:else></f:if>
             ],
             // non-cacheable actions
             [<f:if condition="{plugin.noncacheableControllerActions}"><f:then>
                 <f:for each="{plugin.noncacheableControllerActions}" as="noncachableActionNames" key="noncachableControllerName" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{noncachableControllerName}Controller::class => '<f:for each="{noncachableActionNames}" as="actionName" iteration="i">{actionName}<f:if condition="{i.isLast} == 0">, </f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:then><f:else>
-                <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">'{domainObject.name}' => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator"><f:if condition="{action.cacheable} == 0">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:if></f:for>'<f:if condition="{j.isLast} == 0">,
+                <f:for each="{extension.domainObjectsForWhichAControllerShouldBeBuilt}" as="domainObject" iteration="j">\{extension.vendorName}\{extension.extensionName}\Controller\{domainObject.name}Controller::class => '<f:for each="{domainObject.actions}" as="action" iteration="actionIterator"><f:if condition="{action.cacheable} == 0">{action.name}<f:if condition="{actionIterator.isLast} == 0">, </f:if></f:if></f:for>'<f:if condition="{j.isLast} == 0">,
                 </f:if></f:for></f:else></f:if>
             ]
         );

--- a/Tests/Fixtures/TestExtensions/test_extension/ext_localconf.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/ext_localconf.php
@@ -7,11 +7,11 @@ call_user_func(
             'TestExtension',
             'Testplugin',
             [
-                'Main' => 'list, show, new, create, edit, update, delete'
+                \FIXTURE\TestExtension\Controller\MainController::class => 'list, show, new, create, edit, update, delete'
             ],
             // non-cacheable actions
             [
-                'Main' => 'create, update, delete'
+                \FIXTURE\TestExtension\Controller\MainController::class => 'create, update, delete'
             ]
         );
 


### PR DESCRIPTION
This should fix #296 .
The controllers will be registered correctly now also in case you will not specify you controllers and actions under "Front end plugins" -> "Advanced options".