### PR TITLE
Add missing controller name in configuration to keep the templates

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/edit.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/edit.htmlt
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        Edit.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/list.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/list.htmlt
@@ -8,8 +8,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        List.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/new.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/new.htmlt
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        New.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/show.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/show.htmlt
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        Show.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/edit.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/edit.htmlt
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        Edit.html: keep
+        {domainObject.name}:
+          Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/list.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/list.htmlt
@@ -9,7 +9,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        List.html: keep
+        {domainObject.name}:
+          List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/new.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/new.htmlt
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        New.html: keep
+        {domainObject.name}:
+          New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/show.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Templates/show.htmlt
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        Show.html: keep
+        {domainObject.name}:
+          Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        Edit.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
@@ -9,7 +9,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
     Private:
       Backend:
         Templates:
-          {domainObject.name}:
+          Main:
             Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
@@ -9,7 +9,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
     Private:
       Backend:
         Templates:
-          {domainObject.name}:
+          Main:
             List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        List.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
@@ -9,7 +9,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
     Private:
       Backend:
         Templates:
-          {domainObject.name}:
+          Main:
             New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        New.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
@@ -9,7 +9,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
     Private:
       Backend:
         Templates:
-          {domainObject.name}:
+          Main:
             Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
@@ -7,8 +7,10 @@ If you modify this template, do not forget to change the overwrite settings
 in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
-      Templates:
-        Show.html: keep
+      Backend:
+        Templates:
+          {domainObject.name}:
+            Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Edit.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Edit.html
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        Edit.html: keep
+        {domainObject.name}:
+          Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Edit.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Edit.html
@@ -8,7 +8,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        {domainObject.name}:
+        Main:
           Edit.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/List.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/List.html
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        List.html: keep
+        {domainObject.name}:
+          List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/List.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/List.html
@@ -8,7 +8,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        {domainObject.name}:
+        Main:
           List.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/New.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/New.html
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        New.html: keep
+        {domainObject.name}:
+          New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/New.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/New.html
@@ -8,7 +8,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        {domainObject.name}:
+        Main:
           New.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Show.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Show.html
@@ -8,7 +8,7 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        {domainObject.name}:
+        Main:
           Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Show.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Templates/Main/Show.html
@@ -8,7 +8,8 @@ in /Configuration/ExtensionBuilder/settings.yaml:
   Resources:
     Private:
       Templates:
-        Show.html: keep
+        {domainObject.name}:
+          Show.html: keep
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 


### PR DESCRIPTION
In the explanation example within the template files the name of the object was missing.
For backend modules the backend directory part was also missing in the example.
Only a minor correction but perhaps useful for beginners with extension builder.
I did the change for v10-compatibility branch but it probably may also be merged into master.