### PR TITLE
[BUGFIX] add missing id attribute to HTML templates

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/BooleanProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/BooleanProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.checkbox property="{property.name}" value="1"
+f:form.checkbox property="{property.name}" id="{property.name}" value="1"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/DateProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/DateProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/DateTimeProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/DateTimeProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/EmailProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/EmailProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield type="email" property="{property.name}"
+f:form.textfield type="email" property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/FloatProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/FloatProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/IntegerProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/IntegerProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/NativeDateProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/NativeDateProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<f:format.raw><k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets></f:format.raw>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<f:format.raw><k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets></f:format.raw>"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/NativeDateTimeProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/NativeDateTimeProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<f:format.raw><k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets></f:format.raw>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<f:format.raw><k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets></f:format.raw>"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/PasswordProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/PasswordProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.password property="{property.name}"
+f:form.password property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ManyToManyRelation.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ManyToManyRelation.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ZeroToManyRelation.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ZeroToManyRelation.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ZeroToOneRelation.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/Relation_ZeroToOneRelation.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/RichTextProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/RichTextProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textarea property="{property.name}" cols="40" rows="15"
+f:form.textarea property="{property.name}" id="{property.name}" cols="40" rows="15"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/SelectProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/SelectProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/StringProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/StringProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textfield property="{property.name}"
+f:form.textfield property="{property.name}" id="{property.name}"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/TextProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/TextProperty.htmlt
@@ -1,1 +1,1 @@
-f:form.textarea property="{property.name}" cols="40" rows="15"
+f:form.textarea property="{property.name}" id="{property.name}" cols="40" rows="15"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/TimeProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/TimeProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"

--- a/Resources/Private/CodeTemplates/Extbase/Partials/Form/TimeSecProperty.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Form/TimeSecProperty.htmlt
@@ -1,1 +1,1 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}f:form.textfield property="{property.name}" id="{property.name}" value="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}.{property.name}->f:format.date()</k:curlyBrackets>"

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Partials/Main/FormFields.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Partials/Main/FormFields.html
@@ -2,21 +2,21 @@
 <label for="name">
 	<f:translate key="tx_testextension_domain_model_main.name" />
 </label><br />
-	<f:form.textfield property="name" /><br />
+	<f:form.textfield property="name" id="name" /><br />
 <label for="identifier">
 	<f:translate key="tx_testextension_domain_model_main.identifier" /> <span class="required">(required)</span>
 </label><br />
-	<f:form.textfield property="identifier" /><br />
+	<f:form.textfield property="identifier" id="identifier" /><br />
 <label for="description">
 	<f:translate key="tx_testextension_domain_model_main.description" />
 </label><br />
-	<f:form.textarea property="description" cols="40" rows="15" /><br />
+	<f:form.textarea property="description" id="description" cols="40" rows="15" /><br />
 <label for="myDate">
 	<f:translate key="tx_testextension_domain_model_main.my_date" />
 </label><br />
-	<f:form.textfield property="myDate" value="{main.myDate->f:format.date()}" /><br />
+	<f:form.textfield property="myDate" id="myDate" value="{main.myDate->f:format.date()}" /><br />
 <label for="mail">
         <f:translate key="tx_testextension_domain_model_main.mail" />
 </label><br />
-        <f:form.textfield type="email" property="mail" /><br />
+        <f:form.textfield type="email" property="mail" id="mail" /><br />
 </html>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Partials/Main/FormFields.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Partials/Main/FormFields.html
@@ -2,21 +2,21 @@
 <label for="name">
 	<f:translate key="tx_testextension_domain_model_main.name" />
 </label><br />
-	<f:form.textfield property="name" /><br />
+	<f:form.textfield property="name" id="name" /><br />
 <label for="identifier">
 	<f:translate key="tx_testextension_domain_model_main.identifier" /> <span class="required">(required)</span>
 </label><br />
-	<f:form.textfield property="identifier" /><br />
+	<f:form.textfield property="identifier" id="identifier" /><br />
 <label for="description">
 	<f:translate key="tx_testextension_domain_model_main.description" />
 </label><br />
-	<f:form.textarea property="description" cols="40" rows="15" /><br />
+	<f:form.textarea property="description" id="description" cols="40" rows="15" /><br />
 <label for="myDate">
 	<f:translate key="tx_testextension_domain_model_main.my_date" />
 </label><br />
-	<f:form.textfield property="myDate" value="{main.myDate->f:format.date()}" /><br />
+	<f:form.textfield property="myDate" id="myDate" value="{main.myDate->f:format.date()}" /><br />
 <label for="mail">
         <f:translate key="tx_testextension_domain_model_main.mail" />
 </label><br />
-        <f:form.textfield type="email" property="mail" /><br />
+        <f:form.textfield type="email" property="mail" id="mail" /><br />
 </html>


### PR DESCRIPTION
There was no id-attribute for the label-connection in the new/edit Formfield.html Partial:
<label for="company">
	<f:translate key="tx_erpcustomer_domain_model_customer.company" />
</label><br />
	<f:form.textfield property="company" /><br />

Now it works:
<label for="company">
	<f:translate key="tx_erpcustomer_domain_model_customer.company" />
</label><br />
	<f:form.textfield property="company" id="company" /><br />