### PR TITLE
[BUGFIX] Check object before checking property

### DIFF
--- a/Classes/Parser/Utility/NodeConverter.php
+++ b/Classes/Parser/Utility/NodeConverter.php
@@ -237,7 +237,7 @@ class NodeConverter
         if (is_string($node->$property)) {
             return $node->$property;
         }
-        if (property_exists($node->$property, $property)) {
+        if (is_object($node->$property) && property_exists($node->$property, $property)) {
             return $node->$property->$property;
         }
     }


### PR DESCRIPTION
Backport of commit ID a250d638a9 to fix issue when saving extension due
to a PHP warning ("First parameter must either be an object or the name
of an existing class").

Issue caused by a new(er) version of [nikic/php-parser](https://packagist.org/packages/nikic/php-parser).

Resolves: #339