### PR TITLE
[TASK] Remove "t3ver_label" fields

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/TCA/tableName.phpt
@@ -62,14 +62,6 @@ return [
             'config' => [
                 'type' => 'passthrough',
             ],
-        ],</f:if><f:if condition="{extension.supportVersioning}">
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
         ],</f:if><f:if condition="{domainObject.addHiddenField}">
         'hidden' => [
             'exclude' => true,

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child1.php
@@ -62,14 +62,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child2.php
@@ -62,14 +62,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child3.php
@@ -62,14 +62,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_child4.php
@@ -62,14 +62,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TCA/tx_testextension_domain_model_main.php
@@ -63,14 +63,6 @@ return [
                 'type' => 'passthrough',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',


### PR DESCRIPTION
The "t3ver_label" fields are not used anymore in TYPO3 10 since
https://review.typo3.org/c/Packages/TYPO3.CMS/+/59297/

Adding this field to TCA could cause SQL errors in the backend.