### PR TITLE
Added setL10nModeExclude call for l10mode exclude flag

### DIFF
--- a/Classes/Service/ObjectSchemaBuilder.php
+++ b/Classes/Service/ObjectSchemaBuilder.php
@@ -237,6 +237,9 @@ class ObjectSchemaBuilder implements SingletonInterface
         if (isset($propertyJsonConfiguration['propertyIsExcludeField'])) {
             $property->setExcludeField($propertyJsonConfiguration['propertyIsExcludeField']);
         }
+        if (isset($propertyJsonConfiguration['propertyIsL10nModeExclude'])) {
+            $property->setL10nModeExclude($propertyJsonConfiguration['propertyIsL10nModeExclude']);
+        }
         if ($property->isFileReference() && !empty($propertyJsonConfiguration['maxItems'])) {
             $property->setMaxItems($propertyJsonConfiguration['maxItems']);
         }


### PR DESCRIPTION
The Checkbox in the ExtBuilder FE `Is l10n_mode` didn't did anything because it wasn't settet aynwhere.
Added the `isset` check and call for `setL10nModeExclude`.