### PR TITLE
Show warning when no repository is configured

### DIFF
--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -192,7 +192,7 @@ class BuilderModuleController extends ActionController
     public function domainmodellingAction(): void
     {
         $initialWarnings = [];
-        if ($this->extensionService->isStoragePathConfigured()) {
+        if (!$this->extensionService->isStoragePathConfigured()) {
             $initialWarnings[] = $this->extensionService::COMPOSER_PATH_WARNING;
         }
         $this->view->assignMultiple([


### PR DESCRIPTION
Warning shows up when a repository is configured in composer.json.
Should show up when no repository is configured.