### PR TITLE
Add section 'extra' because of composer warning

### DIFF
--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -890,6 +890,11 @@ class Extension
             ],
             'replace' => [
                 'typo3-ter/' . $composerExtensionKey => 'self.version'
+            ],
+            'extra' => [
+                'typo3/cms' => [
+                    'extension-key' => $this->extensionKey
+                ]
             ]
         ];
         foreach ($this->persons as $person) {


### PR DESCRIPTION
Till today I'm getting this warning for several extension:
```
TYPO3 Extension Package "yoast-seo-for-typo3/yoast_seo", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
```