### PR TITLE
Remove the extension key check 'tt_' prefix

### DIFF
--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -818,7 +818,7 @@ class ExtensionValidator extends AbstractValidator
 
         /*
          * Reserved prefixes
-         * The key must not being with one of the following prefixes: tx,pages,sys_,ts_language_,csh_
+         * The extension key must not have one of the following prefixes: tx,pages,sys_,ts_language_,csh_
          */
         if (preg_match('/^(tx|pages_|sys_|ts_language_|csh_)/', $key)) {
             $this->validationResult['errors'][] = new ExtensionException(

--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -818,9 +818,9 @@ class ExtensionValidator extends AbstractValidator
 
         /*
          * Reserved prefixes
-         * The key must not being with one of the following prefixes: tx,pages,tt_,sys_,ts_language_,csh_
+         * The key must not being with one of the following prefixes: tx,pages,sys_,ts_language_,csh_
          */
-        if (preg_match('/^(tx|pages_|tt_|sys_|ts_language_|csh_)/', $key)) {
+        if (preg_match('/^(tx|pages_|sys_|ts_language_|csh_)/', $key)) {
             $this->validationResult['errors'][] = new ExtensionException(
                 'Illegal extension key prefix',
                 self::ERROR_EXTKEY_ILLEGAL_PREFIX

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -31,7 +31,7 @@ When to use uppercase, lowercase or CamelCase and other restrictions:
 |**Property**       |**Restriction**                                      |**Scope**          |
 +-------------------+-----------------------------------------------------+-------------------+
 |extension_key      |lowercase, alphanumeric, no space                    |Unique in TER      |
-|                   |prefix not:\tx_\|u_\|user_\|pages_\|tt_\|sys_\|csh_  |                   |
+|                   |prefix not:\tx_\|u_\|user_\|pages_\sys_\|csh_        |                   |
 +-------------------+-----------------------------------------------------+-------------------+
 |Extension Name     |No restrictions                                      |No restrictions    |
 +-------------------+-----------------------------------------------------+-------------------+


### PR DESCRIPTION
Why is it not allowed to write an extension like tt_news or tt_products using the extension builder?