### PR TITLE
[BUGFIX] Make backend module templates compatible with TYPO3 10

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Layouts/default.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Layouts/default.htmlt
@@ -1,41 +1,25 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}{escaping off}<f:format.raw><k:openingTag>html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true"</k:openingTag>
-<k:openingTag>f:be.container</k:openingTag>
-    <div class="module">
-        <div class="module-docheader t3js-module-docheader">
-            <div class="module-docheader-bar module-docheader-bar-navigation row">
-                <div class="module-docheader-bar-column-left">
-                    <k:openingTag>f:be.buttons.csh /</k:openingTag>
-                    <k:openingTag>f:be.menus.actionMenu</k:openingTag>
-                        <k:openingTag>f:be.menus.actionMenuItem label="Overview" controller="{domainObject.name}" action="list" /</k:openingTag>
-                        <k:format.removeMultipleNewlines>
-                        <f:for each="{extension.domainObjects}" as="domainObject">
-                            <f:if condition="{domainObject.aggregateRoot}">
-                                <k:openingTag>f:be.menus.actionMenuItem label="Create new {domainObject.name}" action="new" controller="{domainObject.name}" /</k:openingTag>
-                            </f:if>
-                        </f:for>
-                        </k:format.removeMultipleNewlines>
-                    <k:openingTag>/f:be.menus.actionMenu</k:openingTag>
-                </div>
-                <div class="module-docheader-bar-column-right">
-                    <k:openingTag>f:be.pagePath /</k:openingTag>
-                    <k:openingTag>f:be.pageInfo /</k:openingTag>
-                </div>
-            </div>
-            <div class="module-docheader-bar module-docheader-bar-buttons">
-                <div class="module-docheader-bar-column-left">
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}{escaping off}<f:format.raw><k:openingTag>html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true"</k:openingTag>
 
-                </div>
-                <div class="module-docheader-bar-column-right">
-                    <k:openingTag>f:be.buttons.shortcut /</k:openingTag>
-                </div>
-            </div>
-        </div>
-        <div id="module-docbody">
-            <div id="typo3-inner-docbody">
-                <k:openingTag>f:flashMessages /</k:openingTag>
-                <k:openingTag>f:render section="content" /</k:openingTag>
-            </div>
-        </div>
-    </div>
-<k:openingTag>/f:be.container</k:openingTag>
+<k:openingTag>be:moduleLayout</k:openingTag>
+    <k:openingTag>f:be.pageRenderer /</k:openingTag>
+
+    <k:openingTag>be:moduleLayout.menu identifier="ModuleMenu"</k:openingTag>
+        <k:format.removeMultipleNewlines>
+<f:for each="{extension.domainObjects}" as="domainObject">
+        <k:openingTag>be:moduleLayout.menuItem label="Overview" uri="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'list')</k:curlyBrackets>" /</k:openingTag>
+<f:if condition="{domainObject.aggregateRoot}">
+        <k:openingTag>be:moduleLayout.menuItem label="Create new {domainObject.name}" uri="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'new')</k:curlyBrackets>" /</k:openingTag>
+</f:if>
+</f:for>
+        </k:format.removeMultipleNewlines>
+    <k:openingTag>/be:moduleLayout.menu</k:openingTag>
+
+    <k:openingTag>f:render section="Buttons" /</k:openingTag>
+    <k:openingTag>be:moduleLayout.button.shortcutButton displayName="Shortcut" /</k:openingTag>
+
+    <k:openingTag>f:render section="Content" /</k:openingTag>
+<k:openingTag>/be:moduleLayout</k:openingTag>
 <k:openingTag>/html</k:openingTag></f:format.raw>

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/edit.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/edit.htmlt
@@ -1,4 +1,8 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true"</k:openingTag>
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true"</k:openingTag>
+
 <k:openingTag>f:layout name="Default" /</k:openingTag>
 
 This template displays a EDIT form for the current domain object.
@@ -14,7 +18,15 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<k:openingTag>f:section name="content"</k:openingTag>
+<k:openingTag>f:section name="Buttons"</k:openingTag>
+    <k:openingTag>be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="<k:curlyBrackets>f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')</k:curlyBrackets>"
+        link="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'list')</k:curlyBrackets>"
+    /</k:openingTag>
+<k:openingTag>/f:section</k:openingTag>
+
+<k:openingTag>f:section name="Content"</k:openingTag>
     <h1>Edit {domainObject.name}</h1>
 
     <k:openingTag>f:flashMessages /</k:openingTag>
@@ -22,10 +34,10 @@ Otherwise your changes will be overwritten the next time you save the extension 
     <k:openingTag>f:render partial="FormErrors" /</k:openingTag>
 
     <k:format.removeMultipleNewlines>
-    <k:openingTag>f:form action="update" name="{domainObject.name -> k:format.lowercaseFirst()}" object="{domainObject.name -> k:format.lowercaseFirst() -> k:curlyBrackets()}" </k:openingTag>
-    <k:openingTag>f:render partial="{domainObject.name}/FormFields" arguments="<k:curlyBrackets>{domainObject.name-> k:format.lowercaseFirst()}:{domainObject.name-> k:format.lowercaseFirst()}</k:curlyBrackets>" /</k:openingTag>
-    </k:format.removeMultipleNewlines>
-    <k:openingTag>f:form.submit value="Save" /</k:openingTag>
+    <k:openingTag>f:form action="update" name="{domainObject.name -> k:format.lowercaseFirst()}" object="{domainObject.name -> k:format.lowercaseFirst() -> k:curlyBrackets()}"</k:openingTag>
+        <k:openingTag>f:render partial="{domainObject.name}/FormFields" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}: {domainObject.name-> k:format.lowercaseFirst()}</k:curlyBrackets>" /</k:openingTag>
+        <k:openingTag>f:form.submit value="Save" class="btn btn-default" /</k:openingTag>
     <k:openingTag>/f:form</k:openingTag>
+    </k:format.removeMultipleNewlines>
 <k:openingTag>/f:section</k:openingTag>
 <k:openingTag>/html</k:openingTag></f:format.raw>

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/list.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/list.htmlt
@@ -1,4 +1,8 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true"</k:openingTag>
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true"</k:openingTag>
+
 <k:openingTag>f:layout name="Default" /</k:openingTag>
 
 This template is responsible for creating a table of domain objects.
@@ -14,15 +18,21 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<k:openingTag>f:section name="content"</k:openingTag>
+<k:openingTag>f:section name="Buttons"</k:openingTag>
+    <k:openingTag>be:moduleLayout.button.linkButton
+        icon="actions-add"
+        title="<k:curlyBrackets>f:translate(id: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newRecordGeneral')</k:curlyBrackets>"
+        link="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'new')</k:curlyBrackets>"
+    /</k:openingTag>
+<k:openingTag>/f:section</k:openingTag>
+
+<k:openingTag>f:section name="Content"</k:openingTag>
     <h1>Listing for {domainObject.name}</h1>
 
     <k:openingTag>f:flashMessages /</k:openingTag>
 
-    <table  class="{extension.shortExtensionKey}" >
+    <table class="{extension.shortExtensionKey}">
         <k:format.removeMultipleNewlines><tr>
-
-        <f:comment>Building up the table header</f:comment>
             <f:for each="{domainObject.properties}" as="property"><f:if condition="{property.isDisplayable}">
             <th><k:openingTag>f:translate key="{property.labelNamespace}" /</k:openingTag></th>
             </f:if></f:for>
@@ -30,24 +40,20 @@ Otherwise your changes will be overwritten the next time you save the extension 
             <th></th>
         </tr>
         </k:format.removeMultipleNewlines>
-
         <k:format.removeMultipleNewlines>
-        <f:comment>Creating the f:for which loops through all objects</f:comment>
-
         <k:openingTag>f:for each="{domainObject.name -> k:format.lowercaseFirst() -> k:pluralize() -> k:curlyBrackets()}" as="{domainObject.name -> k:format.lowercaseFirst()}"</k:openingTag>
-
             <tr>
             <f:for each="{domainObject.properties}" as="property"><f:if condition="{property.isDisplayable}">
-                <td><k:openingTag>f:link.action action="show" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()} : {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>"</k:openingTag> <k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}.{property.nameToBeDisplayedInFluidTemplate}</k:curlyBrackets><k:openingTag>/f:link.action</k:openingTag></td>
+                <td><k:openingTag>f:link.action action="show" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}: {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>"</k:openingTag><k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}.{property.nameToBeDisplayedInFluidTemplate}</k:curlyBrackets><k:openingTag>/f:link.action</k:openingTag></td>
             </f:if></f:for>
 
-                <td><k:openingTag>f:link.action action="edit" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()} : {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>"</k:openingTag>Edit<k:openingTag>/f:link.action</k:openingTag></td>
-                <td><k:openingTag>f:link.action action="delete" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()} : {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>"</k:openingTag>Delete<k:openingTag>/f:link.action</k:openingTag></td>
+                <td><k:openingTag>f:link.action action="edit" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}: {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>" class="btn btn-default"</k:openingTag>Edit<k:openingTag>/f:link.action</k:openingTag></td>
+                <td><k:openingTag>f:link.action action="delete" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}: {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>" class="btn btn-danger"</k:openingTag>Delete<k:openingTag>/f:link.action</k:openingTag></td>
             </tr>
-            <k:openingTag>/f:for</k:openingTag>
+        <k:openingTag>/f:for</k:openingTag>
         </k:format.removeMultipleNewlines>
     </table>
 
-    <k:openingTag>f:link.action action="new"</k:openingTag>New {domainObject.name}<k:openingTag>/f:link.action</k:openingTag>
+    <k:openingTag>f:link.action action="new" class="btn btn-default"</k:openingTag>New {domainObject.name}<k:openingTag>/f:link.action</k:openingTag>
 <k:openingTag>/f:section</k:openingTag>
 <k:openingTag>/html</k:openingTag></f:format.raw>

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/new.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/new.htmlt
@@ -1,4 +1,8 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true"</k:openingTag>
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true"</k:openingTag>
+
 <k:openingTag>f:layout name="Default" /</k:openingTag>
 
 This template displays a NEW form for the current domain object.
@@ -14,7 +18,15 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<k:openingTag>f:section name="content"</k:openingTag>
+<k:openingTag>f:section name="Buttons"</k:openingTag>
+    <k:openingTag>be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="<k:curlyBrackets>f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')</k:curlyBrackets>"
+        link="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'list')</k:curlyBrackets>"
+    /</k:openingTag>
+<k:openingTag>/f:section</k:openingTag>
+
+<k:openingTag>f:section name="Content"</k:openingTag>
     <h1>New {domainObject.name}</h1>
 
     <k:openingTag>f:flashMessages /</k:openingTag>
@@ -23,9 +35,9 @@ Otherwise your changes will be overwritten the next time you save the extension 
 
     <k:format.removeMultipleNewlines>
     <k:openingTag>f:form action="create" name="new{domainObject.name}" object="<k:curlyBrackets>new{domainObject.name}</k:curlyBrackets>"</k:openingTag>
-    <k:openingTag>f:render partial="{domainObject.name}/FormFields" /</k:openingTag>
-    </k:format.removeMultipleNewlines>
-        <k:openingTag>f:form.submit value="Create new" /</k:openingTag>
+        <k:openingTag>f:render partial="{domainObject.name}/FormFields" /</k:openingTag>
+        <k:openingTag>f:form.submit value="Create new" class="btn btn-default"/</k:openingTag>
     <k:openingTag>/f:form</k:openingTag>
+    </k:format.removeMultipleNewlines>
 <k:openingTag>/f:section</k:openingTag>
 <k:openingTag>/html</k:openingTag></f:format.raw>

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/show.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Backend/Templates/show.htmlt
@@ -1,4 +1,8 @@
-{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true"</k:openingTag>
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:format.raw><k:openingTag>html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true"</k:openingTag>
+
 <k:openingTag>f:layout name="Default" /</k:openingTag>
 
 This template is responsible for displaying a single view for a domain object
@@ -14,12 +18,19 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<k:openingTag>f:section name="content"</k:openingTag>
+<k:openingTag>f:section name="Buttons"</k:openingTag>
+    <k:openingTag>be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="<k:curlyBrackets>f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')</k:curlyBrackets>"
+        link="<k:curlyBrackets>f:uri.action(controller: '{domainObject.name}', action: 'list')</k:curlyBrackets>"
+    /</k:openingTag>
+<k:openingTag>/f:section</k:openingTag>
+
+<k:openingTag>f:section name="Content"</k:openingTag>
     <h1>Single View for {domainObject.name}</h1>
 
     <k:openingTag>f:flashMessages /</k:openingTag>
-    <k:openingTag>f:render partial="{domainObject.name}/Properties" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}:{domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>" /</k:openingTag>
-    <k:openingTag>f:link.action action="list"</k:openingTag>Back to list<k:openingTag>/f:link.action</k:openingTag><br />
-    <k:openingTag>f:link.action action="create"</k:openingTag>New {domainObject.name}<k:openingTag>/f:link.action</k:openingTag>
+    <k:openingTag>f:render partial="{domainObject.name}/Properties" arguments="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}: {domainObject.name -> k:format.lowercaseFirst()}</k:curlyBrackets>" /</k:openingTag>
+    <k:openingTag>f:link.action action="list" class="btn btn-default"</k:openingTag>Back to list<k:openingTag>/f:link.action</k:openingTag>
 <k:openingTag>/f:section</k:openingTag>
 <k:openingTag>/html</k:openingTag></f:format.raw>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Layouts/Default.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Layouts/Default.html
@@ -1,34 +1,23 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:be.container>
-    <div class="module">
-        <div class="module-docheader t3js-module-docheader">
-            <div class="module-docheader-bar module-docheader-bar-navigation row">
-				<div class="module-docheader-bar-column-left">
-					<f:be.buttons.csh />
-					<f:be.menus.actionMenu>
-						<f:be.menus.actionMenuItem label="Overview" controller="" action="list" />
-						<f:be.menus.actionMenuItem label="Create new Main" action="new" controller="Main" />
-					</f:be.menus.actionMenu>
-				</div>
-				<div class="module-docheader-bar-column-right">
-					<f:be.pagePath />
-					<f:be.pageInfo />
-				</div>
-			</div>
-            <div class="module-docheader-bar module-docheader-bar-buttons">
-                <div class="module-docheader-bar-column-left">
-                </div>
-                <div class="module-docheader-bar-column-right">
-                    <f:be.buttons.shortcut />
-                </div>
-            </div>
-		</div>
-		<div id="module-docbody">
-			<div id="typo3-inner-docbody">
-				<f:flashMessages />
-				<f:render section="content" />
-			</div>
-		</div>
-	</div>
-</f:be.container>
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
+<be:moduleLayout>
+    <f:be.pageRenderer />
+
+    <be:moduleLayout.menu identifier="ModuleMenu">
+        <be:moduleLayout.menuItem label="Overview" uri="{f:uri.action(controller: 'Main', action: 'list')}" />
+        <be:moduleLayout.menuItem label="Create new Main" uri="{f:uri.action(controller: 'Main', action: 'new')}" />
+        <be:moduleLayout.menuItem label="Overview" uri="{f:uri.action(controller: 'Child1', action: 'list')}" />
+        <be:moduleLayout.menuItem label="Overview" uri="{f:uri.action(controller: 'Child2', action: 'list')}" />
+        <be:moduleLayout.menuItem label="Overview" uri="{f:uri.action(controller: 'Child3', action: 'list')}" />
+        <be:moduleLayout.menuItem label="Overview" uri="{f:uri.action(controller: 'Child4', action: 'list')}" />
+    </be:moduleLayout.menu>
+
+    <f:render section="Buttons" />
+    <be:moduleLayout.button.shortcutButton displayName="Shortcut" />
+
+    <f:render section="Content" />
+</be:moduleLayout>
 </html>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Edit.html
@@ -1,4 +1,8 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
 <f:layout name="Default" />
 
 This template displays a EDIT form for the current domain object.
@@ -14,16 +18,24 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<f:section name="content">
-	<h1>Edit Main</h1>
+<f:section name="Buttons">
+    <be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="{f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')}"
+        link="{f:uri.action(controller: 'Main', action: 'list')}"
+    />
+</f:section>
 
-	<f:flashMessages />
+<f:section name="Content">
+    <h1>Edit Main</h1>
 
-	<f:render partial="FormErrors" />
+    <f:flashMessages />
 
-	<f:form action="update" name="main" object="{main}" >
-	<f:render partial="Main/FormFields" arguments="{main:main}" />
-		<f:form.submit value="Save" />
-	</f:form>
+    <f:render partial="FormErrors" />
+
+    <f:form action="update" name="main" object="{main}">
+        <f:render partial="Main/FormFields" arguments="{main: main}" />
+        <f:form.submit value="Save" class="btn btn-default" />
+    </f:form>
 </f:section>
 </html>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/List.html
@@ -1,4 +1,8 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
 <f:layout name="Default" />
 
 This template is responsible for creating a table of domain objects.
@@ -14,12 +18,20 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<f:section name="content">
+<f:section name="Buttons">
+    <be:moduleLayout.button.linkButton
+        icon="actions-add"
+        title="{f:translate(id: 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:newRecordGeneral')}"
+        link="{f:uri.action(controller: 'Main', action: 'new')}"
+    />
+</f:section>
+
+<f:section name="Content">
     <h1>Listing for Main</h1>
 
     <f:flashMessages />
 
-    <table  class="tx_testextension" >
+    <table class="tx_testextension">
         <tr>
             <th><f:translate key="tx_testextension_domain_model_main.name" /></th>
             <th><f:translate key="tx_testextension_domain_model_main.identifier" /></th>
@@ -32,17 +44,17 @@ Otherwise your changes will be overwritten the next time you save the extension 
 
         <f:for each="{mains}" as="main">
             <tr>
-                <td><f:link.action action="show" arguments="{main : main}"> {main.name}</f:link.action></td>
-                <td><f:link.action action="show" arguments="{main : main}"> {main.identifier}</f:link.action></td>
-                <td><f:link.action action="show" arguments="{main : main}"> {main.description}</f:link.action></td>
-                <td><f:link.action action="show" arguments="{main : main}"> {main.myDate -> f:format.date()}</f:link.action></td>
-                <td><f:link.action action="show" arguments="{main : main}"> {main.mail}</f:link.action></td>
-                <td><f:link.action action="edit" arguments="{main : main}">Edit</f:link.action></td>
-                <td><f:link.action action="delete" arguments="{main : main}">Delete</f:link.action></td>
+                <td><f:link.action action="show" arguments="{main: main}">{main.name}</f:link.action></td>
+                <td><f:link.action action="show" arguments="{main: main}">{main.identifier}</f:link.action></td>
+                <td><f:link.action action="show" arguments="{main: main}">{main.description}</f:link.action></td>
+                <td><f:link.action action="show" arguments="{main: main}">{main.myDate -> f:format.date()}</f:link.action></td>
+                <td><f:link.action action="show" arguments="{main: main}">{main.mail}</f:link.action></td>
+                <td><f:link.action action="edit" arguments="{main: main}" class="btn btn-default">Edit</f:link.action></td>
+                <td><f:link.action action="delete" arguments="{main: main}" class="btn btn-danger">Delete</f:link.action></td>
             </tr>
         </f:for>
     </table>
 
-    <f:link.action action="new">New Main</f:link.action>
+    <f:link.action action="new" class="btn btn-default">New Main</f:link.action>
 </f:section>
 </html>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/New.html
@@ -1,4 +1,8 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
 <f:layout name="Default" />
 
 This template displays a NEW form for the current domain object.
@@ -14,7 +18,15 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<f:section name="content">
+<f:section name="Buttons">
+    <be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="{f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')}"
+        link="{f:uri.action(controller: 'Main', action: 'list')}"
+    />
+</f:section>
+
+<f:section name="Content">
     <h1>New Main</h1>
 
     <f:flashMessages />
@@ -23,7 +35,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
 
     <f:form action="create" name="newMain" object="{newMain}">
     <f:render partial="Main/FormFields" />
-        <f:form.submit value="Create new" />
+        <f:form.submit value="Create new" class="btn btn-default"/>
     </f:form>
 </f:section>
 </html>

--- a/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
+++ b/Tests/Fixtures/TestExtensions/test_extension/Resources/Private/Backend/Templates/Main/Show.html
@@ -1,4 +1,8 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
 <f:layout name="Default" />
 
 This template is responsible for displaying a single view for a domain object
@@ -14,12 +18,19 @@ in /Configuration/ExtensionBuilder/settings.yaml:
 
 Otherwise your changes will be overwritten the next time you save the extension in the extension builder
 
-<f:section name="content">
+<f:section name="Buttons">
+    <be:moduleLayout.button.linkButton
+        icon="actions-view-go-back"
+        title="{f:translate(id: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.goBack')}"
+        link="{f:uri.action(controller: 'Main', action: 'list')}"
+    />
+</f:section>
+
+<f:section name="Content">
     <h1>Single View for Main</h1>
 
     <f:flashMessages />
-    <f:render partial="Main/Properties" arguments="{main:main}" />
-    <f:link.action action="list">Back to list</f:link.action><br />
-    <f:link.action action="create">New Main</f:link.action>
+    <f:render partial="Main/Properties" arguments="{main: main}" />
+    <f:link.action action="list" class="btn btn-default">Back to list</f:link.action>
 </f:section>
 </html>


### PR DESCRIPTION
The layout was inspired by EXT:beuser backend module.
To keep the template simple, the pagePath and pageInfo has been removed.

Closes #337 