### PR TITLE
[BUGFIX] Check first if the parent class exists

### DIFF
--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -573,16 +573,16 @@ class ExtensionValidator extends AbstractValidator
         $tableName = $domainObject->getMapToTable();
         $extensionPrefix = 'Tx_' . $domainObject->getExtension()->getExtensionName() . '_Domain_Model_';
         if (!empty($parentClass)) {
-            $tableName = $this->configurationManager->getPersistenceTable($parentClass);
-            if (!$tableName) {
-                $this->validationResult['errors'][] = new ExtensionException(
-                    'Mapping configuration error in domain object ' . $domainObject->getName() . ': ' . LF .
-                    'The mapping table could not be detected from Extbase Configuration. Please enter a table name',
-                    self::ERROR_MAPPING_NO_TABLE
-                );
-            }
-
-            if (!class_exists($parentClass, true)) {
+            if (class_exists($parentClass, true)) {
+                $tableName = $this->configurationManager->getPersistenceTable($parentClass);
+                if (!$tableName) {
+                    $this->validationResult['errors'][] = new ExtensionException(
+                        'Mapping configuration error in domain object ' . $domainObject->getName() . ': ' . LF .
+                        'The mapping table could not be detected from Extbase Configuration. Please enter a table name',
+                        self::ERROR_MAPPING_NO_TABLE
+                    );
+                }
+            } else {
                 $this->validationResult['errors'][] = new ExtensionException(
                     'Mapping configuration error in domain object ' . $domainObject->getName() . ': the parent class ' . LF .
                     $parentClass . 'seems not to exist ',

--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -585,7 +585,7 @@ class ExtensionValidator extends AbstractValidator
             } else {
                 $this->validationResult['errors'][] = new ExtensionException(
                     'Mapping configuration error in domain object ' . $domainObject->getName() . ': the parent class ' . LF .
-                    $parentClass . 'seems not to exist ',
+                    $parentClass . ' seems not to exist',
                     self::ERROR_MAPPING_NO_PARENT_CLASS
                 );
             }


### PR DESCRIPTION
It does not make any sense to use the parentClass if it does not exist.