### PR TITLE
requireCHashArgumentForActionArguments is deprecated 

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Configuration/TypoScript/setup.typoscriptt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/TypoScript/setup.typoscriptt
@@ -15,8 +15,6 @@
         #skipDefaultArguments = 1
         # if set to 1, the enable fields are ignored in BE context
         ignoreAllEnableFieldsInBe = 0
-        # Should be on by default, but can be disabled if all action in the plugin are uncached
-        requireCHashArgumentForActionArguments = 1
     }
     mvc {
         #callDefaultActionIfActionCantBeResolved = 1

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/TypoScript/setup.typoscript
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/TypoScript/setup.typoscript
@@ -15,8 +15,6 @@ plugin.tx_testextension_testplugin {
     #skipDefaultArguments = 1
     # if set to 1, the enable fields are ignored in BE context
     ignoreAllEnableFieldsInBe = 0
-    # Should be on by default, but can be disabled if all action in the plugin are uncached
-    requireCHashArgumentForActionArguments = 1
   }
   mvc {
     #callDefaultActionIfActionCantBeResolved = 1


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Deprecation-89868-RemoveReqCHashFunctionalityForPlugins.html?highlight=requirechashargumentforactionarguments