### PR TITLE
[TASK] Adapt public resources url for acceptance tests

### DIFF
--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -176,10 +176,9 @@ class BuilderModuleController extends ActionController
 
         $this->addAssets();
 
-        $extPath = ExtensionManagementUtility::extPath('extension_builder');
         $this->pageRenderer->addInlineSettingArray(
             'extensionBuilder',
-            ['baseUrl' => '../' . PathUtility::stripPathSitePrefix($extPath)]
+            ['publicResourcesUrl' => PathUtility::getPublicResourceWebPath('EXT:extension_builder/Resources/Public')]
         );
 
         $this->setLocallangSettings();

--- a/Resources/Private/Templates/BuilderModule/Domainmodelling.html
+++ b/Resources/Private/Templates/BuilderModule/Domainmodelling.html
@@ -16,7 +16,7 @@
 	</div>
 	<script type="text/javascript">
 		// InputEx needs a correct path to this image
-		inputEx.spacerUrl = TYPO3.settings.extensionBuilder.baseUrl + 'Resources/Public/jsDomainModeling/wireit/lib/inputex/images/space.gif';
+		inputEx.spacerUrl = TYPO3.settings.extensionBuilder.publicResourcesUrl + '/jsDomainModeling/wireit/lib/inputex/images/space.gif';
 
 		YAHOO.util.Event.onDOMReady(function() {
 			const editor = new WireIt.WiringEditor(extbaseModeling_wiringEditorLanguage);

--- a/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
+++ b/Resources/Public/jsDomainModeling/wireit/js/WiringEditor.js
@@ -140,7 +140,7 @@
 		);
 
 		this.showSpinnerPanel.setHeader("Saving, please wait...");
-		this.showSpinnerPanel.setBody('<img src="' + TYPO3.settings.extensionBuilder.baseUrl + 'Resources/Public/jsDomainModeling/wireit/images/loading.gif" />');
+		this.showSpinnerPanel.setBody('<img src="' + TYPO3.settings.extensionBuilder.publicResourcesUrl + '/jsDomainModeling/wireit/images/loading.gif" />');
 		this.showSpinnerPanel.render(document.body);
 
 


### PR DESCRIPTION
Extension Builder public resource url calculation failed in acceptance tests running in a separate TYPO3 instance at 
```
typo3temp/var/tests/acceptance
```
Calculate the url in the same way as the TYPO3 system extensions.

The previous call `PathUtility::stripPathSitePrefix($extPath)` resolved to
```
typo3temp/var/tests/acceptance/typo3/module/typo3conf/ext/extension_builder
```
instead of 
```
typo3temp/var/tests/acceptance/typo3conf/ext/extension_builder
```

Fixes: #519