### PR TITLE
[TASK] Remove plugin type

### DIFF
--- a/Classes/Domain/Model/Plugin.php
+++ b/Classes/Domain/Model/Plugin.php
@@ -21,7 +21,6 @@ class Plugin
 {
     protected string $name = '';
     protected string $description = '';
-    protected ?string $type = '';
     protected string $key = '';
     /**
      * ['controller' => 'MyController', 'actions' => 'action1,action2']
@@ -54,16 +53,6 @@ class Plugin
     public function setName(string $name): void
     {
         $this->name = $name;
-    }
-
-    public function setType(?string $type): void
-    {
-        $this->type = $type;
-    }
-
-    public function getType(): ?string
-    {
-        return $this->type;
     }
 
     public function setKey(string $key): void

--- a/Classes/Factory/PluginFactory.php
+++ b/Classes/Factory/PluginFactory.php
@@ -27,7 +27,6 @@ class PluginFactory
         $plugin = new Plugin();
         $plugin->setName($pluginValues['name']);
         $plugin->setDescription($pluginValues['description']);
-        $plugin->setType($pluginValues['type'] ?? null);
         $plugin->setKey($pluginValues['key']);
 
         if (!empty($pluginValues['actions']['controllerActionCombinations'])) {


### PR DESCRIPTION
The plugin type was meant to be a switch between list type and content type but this is not in use. For content types the extension Mask should be used.