### PR TITLE
[DOCS] Small fixes derived from backport of documentation

### DIFF
--- a/Documentation/GeneratedExtension/Index.rst
+++ b/Documentation/GeneratedExtension/Index.rst
@@ -250,14 +250,11 @@ For example:
    /**
     * @test
     */
-   public function setNameForStringSetsName() {
-       $this->subject->setName('Conceived at T3CON10');
+   public function setTitleForStringSetsTitle(): void
+   {
+      $this->subject->setTitle('Conceived at T3CON10');
 
-       self::assertAttributeEquals(
-           'Conceived at T3CON10',
-           'name',
-           $this->subject
-       );
+      self::assertEquals('Conceived at T3CON10', $this->subject->_get('title'));
    }
 
 All types of properties are covered, for example integers, strings, file
@@ -291,18 +288,17 @@ For example:
    /**
     * @test
     */
-   public function deleteActionRemovesTheGivenBlogFromBlogRepository() {
-       $blog = new \Vendor\Example\Domain\Model\Blog();
+   public function deleteActionRemovesTheGivenBlogFromBlogRepository(): void
+   {
+       $blog = new \Ebt\EbtBlog\Domain\Model\Blog();
 
-       $blogRepository = $this->getMock(
-           \Vendor\Example\Domain\Repository\BlogRepository::class,
-           ['remove'],
-           [],
-           '',
-           false
-       );
+       $blogRepository = $this->getMockBuilder(\Ebt\EbtBlog\Domain\Repository\BlogRepository::class)
+           ->onlyMethods(['remove'])
+           ->disableOriginalConstructor()
+           ->getMock();
+
        $blogRepository->expects(self::once())->method('remove')->with($blog);
-       $this->inject($this->subject, 'blogRepository', $blogRepository);
+       $this->subject->_set('blogRepository', $blogRepository);
 
        $this->subject->deleteAction($blog);
    }

--- a/Documentation/GraphicalEditor/Index.rst
+++ b/Documentation/GraphicalEditor/Index.rst
@@ -308,7 +308,7 @@ TYPO3 content element "General Plugin".
 |                                   |the TYPO3 content element wizard below the plugin name.                                      |
 +-----------------------------------+---------------------------------------------------------------------------------------------+
 |**Controller action combinations** |In each line all actions of a controller supported by this plugin are listed by              |
-|                                   |``<controllerName> => <action1>,<action2>,...``. The first action of the first line is the   |
+|(Advanced options)                 |``<controllerName> => <action1>,<action2>,...``. The first action of the first line is the   |
 |                                   |default action. Actions are defined in the related aggregate root object, and the controller |
 |                                   |name corresponds to the object name.                                                         |
 |                                   |                                                                                             |
@@ -321,7 +321,7 @@ TYPO3 content element "General Plugin".
 |                                   |                                                                                             |
 +-----------------------------------+---------------------------------------------------------------------------------------------+
 |**Non cacheable actions**          |Each line lists all actions of a controller that should not be cached. This list is a subset |
-|                                   |of the *Controller action combinations* property list.                                       |
+|(Advanced options)                 |of the *Controller action combinations* property list.                                       |
 |                                   |                                                                                             |
 |                                   |An example is                                                                                |
 |                                   |                                                                                             |
@@ -357,7 +357,7 @@ backend.
 |                                   |assigned. For example, "web" or "site".                                                      |
 +-----------------------------------+---------------------------------------------------------------------------------------------+
 |**Controller action combinations** |In each line all actions of a controller supported by this module are listed by              |
-|                                   |``<controllerName> => <action1>,<action2>,...``. The first action of the first line is the   |
+|(Advanced options)                 |``<controllerName> => <action1>,<action2>,...``. The first action of the first line is the   |
 |                                   |default action. Actions are defined in the related aggregate root object, and the controller |
 |                                   |name corresponds to the object name.                                                         |
 |                                   |                                                                                             |

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -34,8 +34,8 @@ use_opensearch       =
 [intersphinx_mapping]
 ; in this manual we actually use:
 # Writing documentation
-h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
-t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
-t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/
-t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/
-t3tca         = https://docs.typo3.org/m/typo3/reference-tca/master/en-us/
+h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
+t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+t3tca         = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ TYPO3 Extension ``extension_builder``
 =====================================
 
 The *Extension Builder* helps you to develop a TYPO3 extension based on the
-domain-driven MVC framework `Extbase <https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/0-Introduction/Index.html>`__
-and the templating engine `Fluid <https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/8-Fluid/Index.html>`__.
+domain-driven MVC framework `Extbase <https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/0-Introduction/Index.html>`__
+and the templating engine `Fluid <https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/8-Fluid/Index.html>`__.
 
 It provides a graphical modeler to define domain objects and their relations
 as well as associated controllers with basic actions.
@@ -37,5 +37,5 @@ Finally, it generates a basic extension that can be installed
 and further developed.
 
 :Repository:  https://github.com/FriendsOfTYPO3/extension_builder
-:Read online: https://docs.typo3.org/p/friendsoftypo3/extension-builder/master/en-us/
+:Read online: https://docs.typo3.org/p/friendsoftypo3/extension-builder/main/en-us/
 :TER: https://extensions.typo3.org/extension/extension_builder


### PR DESCRIPTION
- use blog example unit tests instead of dummy unit test
- add "Advanced options" hint in frontend plugin and backend module property descriptions
- apply renaming of "master" branch to "main" of official TYPO3 documentation and repositories

See: #542 