### PR TITLE
[DOCS] Small fixes derived from backport of documentation v11

### DIFF
--- a/Documentation/GeneratedExtension/Index.rst
+++ b/Documentation/GeneratedExtension/Index.rst
@@ -193,7 +193,9 @@ If you publish the extension to the *TYPO3 Extension Repository* (TER), do not
 put the rendered documentation under version control, as the documentation will
 be registered during the :doc:`publishing process </PublishToTer/Index>` for
 automatic rendering and deployment to
-:samp:`https://docs.typo3.org/typo3cms/extensions/<extension_name>/`.
+:samp:`https://docs.typo3.org/p/<vendor-name>/<extension-name>/<version>/<language>/`
+, for example to
+:samp:`https://docs.typo3.org/p/friendsoftypo3/extension-builder/11.0/en-us/`.
 
 If the extension is for private use, you are free to do anything with the
 rendered documentation - including, of course, putting it under version control.

--- a/Documentation/GraphicalEditor/Index.rst
+++ b/Documentation/GraphicalEditor/Index.rst
@@ -58,8 +58,8 @@ Feel encouraged to save frequently.
 +----------------------+----------------------------------------------------------------------------------------------------------+
 |**Key**               |The extension key must be a lowercase, underscored, alphanumeric string.                                  |
 |                      |It must be unique throughout the TER and is best composed of the vendor name and an extension specific    |
-|                      |name, such as ``<vendorname>_<extension_name>``, where it must not start with "tx\_", "u\_", "user\_",    |
-|                      |"pages\_", "sys\_", and "csh\_". It is used                                                               |
+|                      |name, such as ``<vendorname>_<extension_name>``, where it must not start with "tx\_", "pages\_", "sys\_", |
+|                      |"ts\_language\_", and "csh\_". It is used                                                                 |
 |                      |                                                                                                          |
 |                      |- as extension directory name :file:`<extension_key>/`,                                                   |
 |                      |- in the language files: ``product-name=<extension_key>`` and                                             |
@@ -387,8 +387,7 @@ If you run TYPO3 in :doc:`Composer mode <t3start:Installation/Install>`, you
 have to specify and configure a `local path repository <https://getcomposer.org/doc/05-repositories.md#path>`_
 before saving your extension. Extension Builder reads the path from the TYPO3
 project :file:`composer.json` and offers it as a target path to save the
-extension. Extension Builder creates a symlink :file:`typo3conf/ext/<extension_key>/`
-to your extension.
+extension.
 
 The local path repository is normally configured as follows:
 
@@ -414,6 +413,12 @@ To install the extension in the TYPO3 instance you have to execute the usual:
 .. code-block:: bash
 
    composer require ebt/ebt-blog:@dev
+
+which will cause a symlink :file:`typo3conf/ext/<extension_key>/` to your extension
+to be created and the extension to be recognized in the Extension Manager.
+
+Before TYPO3 11.4 you had to install the extension additionally in the Extension
+Manager.
 
 6.b. Legacy mode
 ----------------

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -47,6 +47,7 @@ and further developed:
        ├── ExtensionBuilder.json
        ├── Classes/..
        ├── Configuration/..
+       ├── Documentation/..
        ├── Resources/..
        └── Tests/..
 

--- a/Documentation/PublishToTer/Index.rst
+++ b/Documentation/PublishToTer/Index.rst
@@ -33,4 +33,4 @@ and write appropriate documentation following
 * :ref:`documentation`
 
 before publishing the extension on TER and Packagist, following the official
-:doc:`publishing guide <t3coreapi:ExtensionArchitecture/PublishExtension/Index>`.
+:doc:`publishing guide <t3coreapi-latest:ExtensionArchitecture/PublishExtension/Index>`.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -34,8 +34,9 @@ use_opensearch       =
 [intersphinx_mapping]
 ; in this manual we actually use:
 # Writing documentation
-h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
-t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
-t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
-t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
-t3tca         = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+h2document       = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+t3coreapi        = https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/
+t3coreapi-latest = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+t3extbasebook    = https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/
+t3start          = https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/
+t3tca            = https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ TYPO3 Extension ``extension_builder``
 =====================================
 
 The *Extension Builder* helps you to develop a TYPO3 extension based on the
-domain-driven MVC framework `Extbase <https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/0-Introduction/Index.html>`__
-and the templating engine `Fluid <https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/8-Fluid/Index.html>`__.
+domain-driven MVC framework `Extbase <https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/0-Introduction/Index.html>`__
+and the templating engine `Fluid <https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/8-Fluid/Index.html>`__.
 
 It provides a graphical modeler to define domain objects and their relations
 as well as associated controllers with basic actions.
@@ -37,5 +37,5 @@ Finally, it generates a basic extension that can be installed
 and further developed.
 
 :Repository:  https://github.com/FriendsOfTYPO3/extension_builder
-:Read online: https://docs.typo3.org/p/friendsoftypo3/extension-builder/main/en-us/
+:Read online: https://docs.typo3.org/p/friendsoftypo3/extension-builder/11.0/en-us/
 :TER: https://extensions.typo3.org/extension/extension_builder


### PR DESCRIPTION
- linked to https://docs.typo3.org/p/... instead of outdated https://docs.typo3.org/typo3cms/extensions/...
- compared the list of prefixes for extension names that are not allowed - in description and implementation
- update hint that the generated extension is symlinked by Composer instead of Extension Builder (both is true, but the first is expected)
- add hint of completing the installation in composer mode by installing the extension in the Extension Manager, prior to TYPO3 v11.4
- list the documentation folder also in the generated extension files of the introduction chapter
- always link to the latest version of the extension publishing guide as the steps do not depend on the TYPO3 compatibility of the generated extension
- explicitly set the versions of the linked documentation to v11 to distinguish them from the "latest version" used for the release guide

See: #542