### PR TITLE
[DOCS] Rename slack channel to `#extension-builder`

### DIFF
--- a/Documentation/Contribution/Index.rst
+++ b/Documentation/Contribution/Index.rst
@@ -6,7 +6,7 @@
 Contribution
 ============
 
-If you have a question, please visit the channel `#extension_builder` of
+If you have a question, please visit the channel `#extension-builder` of
 our `Slack workspace <https://typo3.slack.com>`__
 or use `Stack Overflow <https://stackoverflow.com/questions/tagged/typo3>`__.
 


### PR DESCRIPTION
See #570 for details.