### PR TITLE
set backupDir to typo3temp because it exists

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,4 +3,4 @@ enableRoundtrip = 1
 # cat=basic; type=boolean; label=Backup on save: Should the Extension Builder create a backup of the extension every time it is saved?
 backupExtension = 1
 # cat=basic; type=string; label=Backup directory: The directory where the Extension Builder stores the backup - specified as an absolute path or relative to PATH_site.
-backupDir = var/tx_extensionbuilder/backups
+backupDir = typo3temp/var/tx_extensionbuilder/backups


### PR DESCRIPTION
The current default directory for backupDir produces an error message.