### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,12 @@
 		"extension",
 		"extension_builder"
 	],
-	"homepage": "https://github.com/FriendsOfTYPO3/extension_builder",
+	"homepage": "https://extensions.typo3.org/extension/extension_builder",
+	"support": {
+		"issues": "https://github.com/FriendsOfTYPO3/extension_builder/issues",
+		"source": "https://github.com/FriendsOfTYPO3/extension_builder",
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/extension-builder/main/en-us/"
+	},
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{


### PR DESCRIPTION
Added new commit regarding additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185