### PR TITLE
[BUGFIX] Fix PHP8 warning because overwriteSettings not found in empty settings

### DIFF
--- a/Classes/Service/RoundTrip.php
+++ b/Classes/Service/RoundTrip.php
@@ -1025,7 +1025,7 @@ class RoundTrip implements SingletonInterface
             $path = str_replace($extension->getExtensionDir(), '', $path);
         }
         $pathParts = explode('/', $path);
-        $overWriteSettings = $settings['overwriteSettings'];
+        $overWriteSettings = $settings['overwriteSettings'] ?? [];
 
         foreach ($pathParts as $pathPart) {
             if (isset($overWriteSettings[$pathPart]) && is_array($overWriteSettings[$pathPart])) {


### PR DESCRIPTION
There is a warning saving a new extension when debug mode is enabled. 

Tested on:
Ubuntu 20.04
PHP 8.1.4