### PR TITLE
[BUGFIX] Fix warning if setDefaultValuesForClassProperties does not exist

### DIFF
--- a/Classes/Service/ClassBuilder.php
+++ b/Classes/Service/ClassBuilder.php
@@ -211,7 +211,7 @@ class ClassBuilder implements SingletonInterface
                 ));
             }
 
-            if ($domainProperty->getHasDefaultValue() && $this->settings['setDefaultValuesForClassProperties'] !== false) {
+            if ($domainProperty->getHasDefaultValue() && ($this->settings['setDefaultValuesForClassProperties'] ?? false) !== false) {
                 $classProperty->setDefault($domainProperty->getDefaultValue());
             }
             if ($domainProperty->isNullableProperty() === true && $domainProperty->getNullable() === true) {


### PR DESCRIPTION
On first saving a warning is shown that array key `setDefaultValuesForClassProperties` does not exist