### PR TITLE
[BUGFIX] Generate correct .xlf files

### DIFF
--- a/Classes/Service/LocalizationService.php
+++ b/Classes/Service/LocalizationService.php
@@ -64,7 +64,7 @@ class LocalizationService implements SingletonInterface
             foreach ($domainObject->getProperties() as $property) {
                 $labelArray[$property->getLabelNamespace()] = Inflector::humanize($property->getName());
             }
-            if ($type === 'locallang_db') {
+            if ($type === 'locallang_db.xlf') {
                 $tableToMapTo = $domainObject->getMapToTable();
                 if (!empty($tableToMapTo)) {
                     $labelArray[$tableToMapTo . '.tx_extbase_type.' . $domainObject->getRecordType()] = $extension->getName() . ' ' . $domainObject->getName();
@@ -76,7 +76,7 @@ class LocalizationService implements SingletonInterface
                 }
             }
         }
-        if ($type === 'locallang_db' && $extension->hasPlugins()) {
+        if ($type === 'locallang_db.xlf' && $extension->hasPlugins()) {
             foreach ($extension->getPlugins() as $plugin) {
                 $labelArray['tx_' . $extension->getExtensionKey() . '_' . $plugin->getKey() . '.name'] = $plugin->getName();
                 $labelArray['tx_' . $extension->getExtensionKey() . '_' . $plugin->getKey() . '.description'] = $plugin->getDescription();


### PR DESCRIPTION
The LocalizationService didn't generate the entries for the plugin name and description.

The variable `$type` is filled with the complete file extension, so it will be `locallang_db.xlf` instead of `locallang_db`.

See this line: https://github.com/FriendsOfTYPO3/extension_builder/blob/c5ba89bfefccf9322b9fecaffb1a3cc1af02f426/Classes/Service/FileGenerator.php#L1182

will fix #603 
will fix #529 