### PR TITLE
[BUGFIX] Language file not merged

### DIFF
--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -1151,10 +1151,9 @@ class FileGenerator
             if ($variableName === 'domainObject') {
                 $filenameToLookFor .= '_' . $variable->getDatabaseTableName();
             }
-            $existingFile = $filenameToLookFor . '.xlf';
 
-            if (@file_exists($existingFile)) {
-                $existingLabels = $this->localizationService->getLabelArrayFromFile($existingFile, 'default');
+            if (@file_exists($filenameToLookFor)) {
+                $existingLabels = $this->localizationService->getLabelArrayFromFile($filenameToLookFor, 'default');
                 if (is_array($existingLabels)) {
                     ArrayUtility::mergeRecursiveWithOverrule($languageLabels, $existingLabels);
                 }

--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -1146,11 +1146,8 @@ class FileGenerator
 
         $languageLabels = $this->getLanguageLabelsForVariable($variableName, $variable, $fileNameSuffix);
 
-        if ($this->fileShouldBeMerged($targetFile . '.xlf')) {
+        if ($this->fileShouldBeMerged($targetFile)) {
             $filenameToLookFor = $this->extensionDirectory . $targetFile;
-            if ($variableName === 'domainObject') {
-                $filenameToLookFor .= '_' . $variable->getDatabaseTableName();
-            }
 
             if (@file_exists($filenameToLookFor)) {
                 $existingLabels = $this->localizationService->getLabelArrayFromFile($filenameToLookFor, 'default');


### PR DESCRIPTION
The language files inside Resources/Private/Language were not merged, after saving the extension inside the extension builder. It happened because the suffix was added twice.

will fix #565 