### PR TITLE
[BUGFIX] fixes title for advanced option button

### DIFF
--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -302,7 +302,7 @@ class BuilderModuleController extends ActionController
     {
         $advancedOptionsButton = GeneralUtility::makeInstance(LinkButtonWithId::class)
             ->setIcon($this->iconFactory->getIcon('content-menu-pages', Icon::SIZE_SMALL))
-            ->setTitle('<span class="simpleMode">Show</span><span class="advancedMode">Hide</span> advanced options.')
+            ->setTitle($this->getLanguageService()->sL('LLL:EXT:extension_builder/Resources/Private/Language/locallang.xlf:advancedOptions'))
             ->setId('toggleAdvancedOptions')
             ->setHref('#')
             ->setShowLabelText(true);

--- a/Classes/Template/Components/Buttons/LinkButtonWithId.php
+++ b/Classes/Template/Components/Buttons/LinkButtonWithId.php
@@ -59,7 +59,7 @@ class LinkButtonWithId extends LinkButton
         ];
         $labelText = '';
         if ($this->showLabelText) {
-            $labelText = ' ' . $this->title;
+            $labelText = ' <span class="simpleMode">Show</span><span class="advancedMode">Hide</span> ' . $this->title . '.';
         }
         foreach ($this->dataAttributes as $attributeName => $attributeValue) {
             $attributes['data-' . $attributeName] = $attributeValue;

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -227,7 +227,7 @@
 				<source>More options</source>
 			</trans-unit>
 			<trans-unit id="advancedOptions" resname="advancedOptions">
-				<source>Advanced options</source>
+				<source>advanced options</source>
 			</trans-unit>
 			<trans-unit id="remove" resname="remove">
 				<source>Remove</source>


### PR DESCRIPTION
The title of advanced options button had html inside, so the title was displayed faulty.

Fixes #536 