### PR TITLE
[BUGFIX] Add default for Extension::getStoragePath()

### DIFF
--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -574,7 +574,7 @@ class Extension
 
     public function getStoragePath(): ?string
     {
-        return $this->storagePath;
+        return $this->storagePath ?? Environment::getPublicPath() . '/typo3conf/ext/';
     }
 
     public function setStoragePath(?string $storagePath): void


### PR DESCRIPTION
For non-composer-mode in certain cases the storagePath can not be determined. Add a default.

Fixes: #355