### PR TITLE
[TASK] Use current standard for web-dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Execute unit tests
         run: .Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit/
         env:
-          TYPO3_PATH_WEB: $PWD/.Build/public
+          TYPO3_PATH_WEB: $PWD/.Build/Web
 
       - name: Execute functional tests
         run: .Build/bin/phpunit --colors  -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/
         env:
-          TYPO3_PATH_WEB: $PWD/.Build/public
+          TYPO3_PATH_WEB: $PWD/.Build/Web
           typo3DatabaseDriver: pdo_sqlite

--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -675,7 +675,7 @@ class Extension
             ],
             'extra' => [
                 'typo3/cms' => [
-                    'web-dir' => '.Build/public',
+                    'web-dir' => '.Build/Web',
                     'extension-key' => $extensionKey,
                 ]
             ]

--- a/Tests/Fixtures/TestExtensions/test_extension/composer.json
+++ b/Tests/Fixtures/TestExtensions/test_extension/composer.json
@@ -39,7 +39,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"web-dir": ".Build/public",
+			"web-dir": ".Build/Web",
 			"extension-key": "test_extension"
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,8 @@
 		"prepare-extension-test-structure": [
 			"TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
 		],
-		"unit-tests": "TYPO3_PATH_ROOT=$PWD/.Build/public .Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --stop-on-failure Tests/Unit",
-		"functional-tests": "TYPO3_PATH_ROOT=$PWD/.Build/public typo3DatabaseDriver=pdo_sqlite .Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --stop-on-failure Tests/Functional",
+		"unit-tests": "TYPO3_PATH_ROOT=$PWD/.Build/Web .Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --stop-on-failure Tests/Unit",
+		"functional-tests": "TYPO3_PATH_ROOT=$PWD/.Build/Web typo3DatabaseDriver=pdo_sqlite .Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --stop-on-failure Tests/Functional",
 		"test": [
 			"@test-php-cs-fixer",
 			"@unit-tests",
@@ -81,7 +81,7 @@
 			"extension-key": "extension_builder",
 			"app-dir": ".Build",
 			"ignore-as-root": false,
-			"web-dir": ".Build/public"
+			"web-dir": ".Build/Web"
 		}
 	}
 }


### PR DESCRIPTION
To make contribution and maintainance of configuration, scripts etc. for testing easier, we try to use a common standard across TYPO3 extensions.

The current standard is:

- web-dir: .Build/Web
- bin-dir: .Build/bin
- vendor-dir: .Build/vendor

This is used in the official example extensions (tea, docs-examples) as well as in most of the checked community extensions (in a subset of 20 of the most popular v12 extensions).

As extension_builder is very influential in this area and is used to create extensions from scratch, it is useful to stick to the standard in this extension as well.

Related: TYPO3-Documentation/tea#802