### PR TITLE
[BUGFIX] Undefined array key

### DIFF
--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -428,7 +428,7 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
             return $result;
         }
 
-        if ($modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid'] === $uid) {
+        if (isset($modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid']) && $modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid'] === $uid) {
             $result['terminal'] = 'relationWire_' . $supposedRelationIndex;
             return $result;
         }

--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -428,7 +428,10 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
             return $result;
         }
 
-        if (isset($modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid']) && $modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid'] === $uid) {
+        if (
+            isset($modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid']) 
+            && $modules[$supposedModuleIndex]['value']['relationGroup']['relations'][$supposedRelationIndex]['uid'] === $uid
+        ) {
             $result['terminal'] = 'relationWire_' . $supposedRelationIndex;
             return $result;
         }


### PR DESCRIPTION
After deleting a relation wire I got this error:
`Extension could not be saved: PHP Warning: Undefined array key 22 in /html/typo3/typo3conf/ext/extension_builder/Classes/Configuration/ExtensionBuilderConfigurationManager.php line 431`

PHP 8.2

This change seems to work.