### PR TITLE
[TASK] Remove "replace" section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
 			"EBT\\ExtensionBuilder\\Tests\\": "Tests/"
 		}
 	},
-	"replace": {
-		"typo3-ter/extension-builder": "self.version"
-	},
 	"config": {
 		"bin-dir": ".Build/bin",
 		"vendor-dir": ".Build/vendor",


### PR DESCRIPTION
This setting is not considered anymore, see:
https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/FileStructure/ComposerJson.html#replace-with-ext-key-self-version