### PR TITLE
[TASK] Remove preferred-install setting from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,9 +49,6 @@
 	"config": {
 		"bin-dir": ".Build/bin",
 		"vendor-dir": ".Build/vendor",
-		"preferred-install": {
-			"*": "dist"
-		},
 		"allow-plugins": {
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true


### PR DESCRIPTION
They default is "dist" since Composer 2.1, so this setting is superfluous now: https://getcomposer.org/doc/06-config.md#preferred-install