### PR TITLE
[FEATURE] Skip rewriting XLF files when only the timestamp changed

### DIFF
--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -1515,10 +1515,37 @@ class FileGenerator
         if (empty($fileContents)) {
             return;
         }
+
+        // Skip writing XLF files when only the date= attribute has changed to avoid VCS noise
+        if (
+            strtolower(pathinfo($targetFile, PATHINFO_EXTENSION)) === 'xlf'
+            && $this->xlfContentIsUnchanged($targetFile, $fileContents)
+        ) {
+            return;
+        }
+
         $success = GeneralUtility::writeFile($targetFile, $fileContents);
         if (!$success) {
             throw new Exception('File ' . $targetFile . ' could not be created!');
         }
+    }
+
+    /**
+     * Checks whether an existing XLF file has the same content as $newContent,
+     * ignoring differences in the date= attribute.
+     * Used to avoid rewriting XLF files when only the timestamp changed.
+     */
+    private function xlfContentIsUnchanged(string $targetFile, string $newContent): bool
+    {
+        if (!file_exists($targetFile)) {
+            return false;
+        }
+        $existing = file_get_contents($targetFile);
+        if ($existing === false) {
+            return false;
+        }
+        $normalize = static fn(string $content): string => (string)preg_replace('/\bdate="[^"]*"/', 'date=""', $content);
+        return $normalize($existing) === $normalize($newContent);
     }
 
     /**

--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -6,6 +6,11 @@
 Change log
 ==========
 
+Version 13.1.0
+--------------
+
+* [FEATURE] XLF files are no longer rewritten when only the ``date=`` attribute changed — avoids VCS noise on every regeneration. The ``staticDateInXliffFiles`` setting is removed as it is no longer needed.
+
 Version 12.0.0
 --------------
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -168,19 +168,10 @@ This is an example of the :file:`settings.yaml` file:
 Miscellaneous
 -------------
 
-There are more options both for the timestamps of the language files and for
-working with the Extension Builder itself.
+There are more options for working with the Extension Builder itself.
 
 +----------------------------+-------------------------------------------------------------------------------+
 |**Setting**                 |**Description**                                                                |
-+----------------------------+-------------------------------------------------------------------------------+
-|staticDateInXliffFiles      |By default, the date attribute in language files is updated every time you     |
-|                            |save in the Extension Builder.                                                 |
-|                            |This can be confusing in a version control system if all language files are    |
-|                            |marked as changed even if no labels have been added or changed.                |
-|                            |To prevent this effect, you can set a static date –                            |
-|                            |although this is not recommended because the modification date can be useful   |
-|                            |in the translation context.                                                    |
 +----------------------------+-------------------------------------------------------------------------------+
 |ignoreWarnings              |Some modeling configurations result in warnings.                               |
 |                            |For example, if you configure a show action as a default action, you are       |
@@ -194,8 +185,6 @@ working with the Extension Builder itself.
 This is an example of the :file:`settings.yaml` file:
 
 .. code-block:: yaml
-
-   staticDateInXliffFiles: 2021-11-18T12:37:00Z
 
    ignoreWarnings:
      503

--- a/Resources/Private/CodeTemplates/Extbase/Configuration/ExtensionBuilder/settings.yamlt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/ExtensionBuilder/settings.yamlt
@@ -68,9 +68,6 @@ overwriteSettings:
 ## add declare strict types in php files
 declareStrictTypes: true
 
-## use static date attribute in xliff files
-#staticDateInXliffFiles: '{f:format.date(format:'Y-m-d\TH:i:s\Z',date:'now')}'
-
 ## skip docComment (license header)
 #skipDocComment: false
 

--- a/Resources/Private/CodeTemplates/Extbase/Resources/Private/Language/locallang.xlft
+++ b/Resources/Private/CodeTemplates/Extbase/Resources/Private/Language/locallang.xlft
@@ -1,6 +1,6 @@
 {namespace k=EBT\ExtensionBuilder\ViewHelpers}<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
-	<file source-language="{extension.sourceLanguage}" datatype="plaintext" original="{fileName}" date="{f:if(condition:extension.settings.staticDateInXliffFiles, then:'{extension.settings.staticDateInXliffFiles}', else: '{f:format.date(format:\'Y-m-d\\TH:i:s\\Z\',date:\'now\')}')}" product-name="{extension.extensionKey}">
+	<file source-language="{extension.sourceLanguage}" datatype="plaintext" original="{fileName}" date="{f:format.date(format:'Y-m-d\TH:i:s\Z',date:'now')}" product-name="{extension.extensionKey}">
 		<header/>
 		<body><f:for each="{labelArray}" as="label" key="index">
 			<trans-unit id="{index}" resname="{index}">

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Configuration/ExtensionBuilder/settings.yaml
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Configuration/ExtensionBuilder/settings.yaml
@@ -68,9 +68,6 @@ overwriteSettings:
 ## add declare strict types in php files
 declareStrictTypes: true
 
-## use static date attribute in xliff files
-#staticDateInXliffFiles: '2026-04-06T19:20:13Z'
-
 ## skip docComment (license header)
 #skipDocComment: false
 

--- a/Tests/Fixtures/TestExtensions/test_extension/Configuration/ExtensionBuilder/settings.yaml
+++ b/Tests/Fixtures/TestExtensions/test_extension/Configuration/ExtensionBuilder/settings.yaml
@@ -70,9 +70,6 @@ overwriteSettings:
 
 #  ext_tables.sql: merge
 
-## use static date attribute in xliff files ##
-#staticDateInXliffFiles: ###YEAR###-01-01T01:00:00Z
-
 ## list of error codes for warnings that should be ignored ##
 #ignoreWarnings:
   #503

--- a/Tests/Unit/Service/FileGeneratorXlfTest.php
+++ b/Tests/Unit/Service/FileGeneratorXlfTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace EBT\ExtensionBuilder\Tests\Unit\Service;
+
+use EBT\ExtensionBuilder\Service\ClassBuilder;
+use EBT\ExtensionBuilder\Service\FileGenerator;
+use EBT\ExtensionBuilder\Service\LocalizationService;
+use EBT\ExtensionBuilder\Service\Printer;
+use EBT\ExtensionBuilder\Service\RoundTrip;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use ReflectionClass;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class FileGeneratorXlfTest extends UnitTestCase
+{
+    private FileGenerator $fileGenerator;
+    private vfsStreamDirectory $vfsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vfsRoot = vfsStream::setup('root');
+
+        $this->fileGenerator = new FileGenerator(
+            $this->createMock(ClassBuilder::class),
+            $this->createMock(RoundTrip::class),
+            $this->createMock(Printer::class),
+            $this->createMock(LocalizationService::class),
+            $this->createMock(ViewFactoryInterface::class),
+            $this->createMock(ExtensionConfiguration::class),
+        );
+    }
+
+    private function callXlfContentIsUnchanged(string $targetFile, string $newContent): bool
+    {
+        $ref = new ReflectionClass($this->fileGenerator);
+        $method = $ref->getMethod('xlfContentIsUnchanged');
+        return $method->invoke($this->fileGenerator, $targetFile, $newContent);
+    }
+
+    private function xlf(string $date, string $label = 'Hello'): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+            <xliff version="1.0">
+                <file source-language="en" datatype="plaintext" original="locallang.xlf" date="{$date}" product-name="my_ext">
+                    <header/>
+                    <body>
+                        <trans-unit id="general.yes" resname="general.yes">
+                            <source>{$label}</source>
+                        </trans-unit>
+                    </body>
+                </file>
+            </xliff>
+            XML;
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFalseWhenFileDoesNotExist(): void
+    {
+        $path = vfsStream::url('root/locallang.xlf');
+        self::assertFalse($this->callXlfContentIsUnchanged($path, $this->xlf('2025-01-01T00:00:00Z')));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsTrueWhenOnlyDateAttributeDiffers(): void
+    {
+        $path = vfsStream::url('root/locallang.xlf');
+        vfsStream::newFile('locallang.xlf')
+            ->withContent($this->xlf('2020-01-01T00:00:00Z'))
+            ->at($this->vfsRoot);
+
+        self::assertTrue($this->callXlfContentIsUnchanged($path, $this->xlf('2026-04-11T12:00:00Z')));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFalseWhenLabelChanged(): void
+    {
+        $path = vfsStream::url('root/locallang.xlf');
+        vfsStream::newFile('locallang.xlf')
+            ->withContent($this->xlf('2020-01-01T00:00:00Z', 'Hello'))
+            ->at($this->vfsRoot);
+
+        self::assertFalse($this->callXlfContentIsUnchanged($path, $this->xlf('2026-04-11T12:00:00Z', 'Goodbye')));
+    }
+}


### PR DESCRIPTION
## Problem

Every time the Extension Builder regenerates code, all XLF language files were rewritten to disk — even when no labels changed. The `date=` attribute in the `<file>` element is set to the current timestamp on every run, causing all XLF files to show up as modified in version control.

There was already a workaround (`staticDateInXliffFiles` in `settings.yaml`), but it required manual configuration per extension and wasn't convenient.

Closes #116

## Solution

`FileGenerator::writeFile()` now compares the normalized content of the new and existing XLF file before writing. The `date=` attribute value is stripped from both strings before comparison. If they are equal, the write is skipped and the file retains its original mtime — no VCS noise.

The `staticDateInXliffFiles` setting is removed as it is no longer needed.

## Changes

- `Classes/Service/FileGenerator.php` — new `xlfContentIsUnchanged()` helper + early-return in `writeFile()` for `.xlf` files
- `Resources/Private/CodeTemplates/Extbase/Resources/Private/Language/locallang.xlft` — simplified (removed `f:if` for static date)
- `Resources/Private/CodeTemplates/Extbase/Configuration/ExtensionBuilder/settings.yamlt` — removed `staticDateInXliffFiles` option
- `Tests/Fixtures/` — removed `staticDateInXliffFiles` from test fixtures
- `Documentation/Configuration/Index.rst` — removed setting documentation
- `Documentation/ChangeLog/Index.rst` — added entry under 13.1.0
- `Tests/Unit/Service/FileGeneratorXlfTest.php` — new unit tests (3 cases)

## Test plan

- [ ] Verify XLF files are not rewritten on regeneration when no labels changed
- [ ] Verify XLF files are rewritten when a label is added or changed
- [ ] Unit tests pass: `phpunit Tests/Unit/Service/FileGeneratorXlfTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)