### PR TITLE
[BUGFIX] #673: generate ext_tables.sql CREATE TABLE for models without own properties

### DIFF
--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -80,6 +80,10 @@ class ExtensionValidator extends AbstractValidator
     /**
      * @var int
      */
+    public const ERROR_DOMAINOBJECT_NO_PROPERTIES = 104;
+    /**
+     * @var int
+     */
     public const ERROR_PROPERTY_NO_NAME = 200;
     /**
      * @var int
@@ -543,6 +547,15 @@ class ExtensionValidator extends AbstractValidator
                 $this->validationResult['errors'][] = new ExtensionException(
                     'Domain object name "' . $domainObject->getName() . '" may not be used in extbase.',
                     self::ERROR_PROPERTY_RESERVED_WORD
+                );
+            }
+
+            if (!count($domainObject->getProperties())) {
+                $this->validationResult['warnings'][] = new ExtensionException(
+                    'Domain object "' . $domainObject->getName() . '" has no properties.' . LF
+                    . 'Without properties, no CREATE TABLE statement will be generated in ext_tables.sql.' . LF
+                    . 'Add at least one property to ensure the database table is created correctly.',
+                    self::ERROR_DOMAINOBJECT_NO_PROPERTIES
                 );
             }
 

--- a/Classes/Domain/Validator/ExtensionValidator.php
+++ b/Classes/Domain/Validator/ExtensionValidator.php
@@ -550,7 +550,7 @@ class ExtensionValidator extends AbstractValidator
                 );
             }
 
-            if (!count($domainObject->getProperties())) {
+            if (!count($domainObject->getProperties()) && !$this->hasIncomingFkRelation($domainObject, $extension)) {
                 $this->validationResult['warnings'][] = new ExtensionException(
                     'Domain object "' . $domainObject->getName() . '" has no properties.' . LF
                     . 'Without properties, no CREATE TABLE statement will be generated in ext_tables.sql.' . LF
@@ -577,6 +577,26 @@ class ExtensionValidator extends AbstractValidator
                 );
             }
         }
+    }
+
+    /**
+     * Returns true if any other domain object in the extension has an inline ZeroToMany relation
+     * pointing to $domainObject, meaning a FK column will be generated in ext_tables.sql even
+     * when $domainObject has no own properties.
+     */
+    private function hasIncomingFkRelation(DomainObject $domainObject, Extension $extension): bool
+    {
+        foreach ($extension->getDomainObjects() as $otherObject) {
+            foreach ($otherObject->getProperties() as $property) {
+                if ($property instanceof ZeroToManyRelation
+                    && $property->getRenderType() === 'inline'
+                    && $property->getForeignClassName() === $domainObject->getFullQualifiedClassName()
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -9,6 +9,8 @@ Change log
 Version 13.1.0
 --------------
 
+* [BUGFIX] ``ext_tables.sql`` now includes a ``CREATE TABLE`` statement for models that have no own properties but are the target of a ``ZeroToMany inline`` relation — previously the FK column was silently dropped, leaving the database table uncreated.
+* [BUGFIX] A validation warning is now shown when a domain object has no properties, informing the user that no ``CREATE TABLE`` statement will be generated in ``ext_tables.sql``.
 * [FEATURE] XLF files are no longer rewritten when only the ``date=`` attribute changed — avoids VCS noise on every regeneration. The ``staticDateInXliffFiles`` setting is removed as it is no longer needed.
 
 Version 12.0.0

--- a/Resources/Private/CodeTemplates/Extbase/extTables.sqlt
+++ b/Resources/Private/CodeTemplates/Extbase/extTables.sqlt
@@ -1,6 +1,6 @@
 {namespace k=EBT\ExtensionBuilder\ViewHelpers}{escaping off}<k:format.trim>
 <f:for each="{extension.domainObjects}" as="domainObject">
-<f:if condition="{domainObject.properties -> f:count()} > 0 || {k:domainObjectChecks(renderCondition: 'needsTypeField', domainObject: domainObject)}">
+<f:if condition="{domainObject.properties -> f:count()} > 0 || {k:domainObjectChecks(renderCondition: 'needsTypeField', domainObject: domainObject)} || {k:listForeignKeyRelations(domainObject:domainObject) -> f:count()} > 0">
 CREATE TABLE {domainObject.databaseTableName} (<f:for each="{k:listForeignKeyRelations(domainObject:domainObject)}" as="relation">
 	{relation.foreignKeyName} int unsigned DEFAULT '0' NOT NULL,</f:for><f:for each="{domainObject.properties}" as="property"><f:if condition="{property.isPersistable}">
 	{property.sqlDefinition}</f:if></f:for><k:mapping renderCondition="needsTypeField" domainObject="{domainObject}">

--- a/Tests/Functional/Service/FileGeneratorTest.php
+++ b/Tests/Functional/Service/FileGeneratorTest.php
@@ -482,6 +482,52 @@ class FileGeneratorTest extends BaseFunctionalTest
     }
 
     /**
+     * Verify that ext_tables.sql contains a CREATE TABLE for a child model that has no own properties
+     * but is the target of a ZeroToMany inline relation (requires FK column in its table).
+     *
+     * @test
+     */
+    public function extTablesSqlContainsForeignKeyForChildModelWithNoProperties(): void
+    {
+        $ownerModelName = 'OwnerModel';
+        $childModelName = 'ChildModel';
+        $relationName = 'children';
+
+        $ownerDomainObject = $this->buildDomainObject($ownerModelName, true, true);
+        $childDomainObject = $this->buildDomainObject($childModelName, true);
+
+        $property = new BooleanProperty('active');
+        $ownerDomainObject->addProperty($property);
+
+        $relation = new Relation\ZeroToManyRelation($relationName);
+        $relation->setForeignModel($childDomainObject);
+        $relation->setRenderType('inline');
+        $ownerDomainObject->addProperty($relation);
+
+        $this->extension->addDomainObject($ownerDomainObject);
+        $this->extension->addDomainObject($childDomainObject);
+
+        $this->fileGenerator->build($this->extension);
+
+        $sqlFile = $this->extension->getExtensionDir() . 'ext_tables.sql';
+        self::assertFileExists($sqlFile, 'ext_tables.sql was not generated');
+
+        $sqlContent = file_get_contents($sqlFile);
+        self::assertStringContainsString(
+            'CREATE TABLE ' . $childDomainObject->getDatabaseTableName(),
+            $sqlContent,
+            'ext_tables.sql must contain CREATE TABLE for child model with no own properties'
+        );
+        // FK column name is derived from the owner model name (lowercase)
+        $expectedFkColumn = strtolower($ownerModelName);
+        self::assertStringContainsString(
+            $expectedFkColumn,
+            $sqlContent,
+            'ext_tables.sql must contain the FK column for the child model'
+        );
+    }
+
+    /**
      * @test
      */
     public function writeExtensionFiles(): void

--- a/Tests/Unit/Domain/Validator/ValidationServiceTest.php
+++ b/Tests/Unit/Domain/Validator/ValidationServiceTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace EBT\ExtensionBuilder\Tests\Unit\Domain\Validator;
 
 use EBT\ExtensionBuilder\Domain\Exception\ExtensionException;
+use EBT\ExtensionBuilder\Domain\Model\DomainObject\Relation\ZeroToManyRelation;
 use EBT\ExtensionBuilder\Domain\Validator\ExtensionValidator;
 use EBT\ExtensionBuilder\Tests\BaseUnitTest;
 
@@ -48,6 +49,32 @@ class ValidationServiceTest extends BaseUnitTest
             ExtensionValidator::ERROR_DOMAINOBJECT_NO_PROPERTIES,
             $warningCodes,
             'Expected warning for domain object without properties'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function noWarningForDomainObjectWithNoPropertiesWhenItIsInlineFkTarget(): void
+    {
+        $ownerObject = $this->buildDomainObject('OwnerModel', true, true);
+        $childObject = $this->buildDomainObject('ChildModel', true);
+        // child has no own properties, but is target of an inline ZeroToMany relation
+        $relation = new ZeroToManyRelation('children');
+        $relation->setForeignModel($childObject);
+        $relation->setRenderType('inline');
+        $ownerObject->addProperty($relation);
+        $this->extension->addDomainObject($ownerObject);
+        $this->extension->addDomainObject($childObject);
+
+        $extensionValidator = new ExtensionValidator();
+        $result = $extensionValidator->validateExtension($this->extension);
+
+        $warningCodes = array_map(fn($w) => $w->getCode(), $result['warnings']);
+        self::assertNotContains(
+            ExtensionValidator::ERROR_DOMAINOBJECT_NO_PROPERTIES,
+            $warningCodes,
+            'No warning expected for child model that is target of an inline FK relation'
         );
     }
 

--- a/Tests/Unit/Domain/Validator/ValidationServiceTest.php
+++ b/Tests/Unit/Domain/Validator/ValidationServiceTest.php
@@ -34,6 +34,26 @@ class ValidationServiceTest extends BaseUnitTest
     /**
      * @test
      */
+    public function validateExtensionWarnsForDomainObjectWithNoProperties(): void
+    {
+        $domainObject = $this->buildDomainObject('EmptyModel');
+        // no properties added
+        $this->extension->addDomainObject($domainObject);
+
+        $extensionValidator = new ExtensionValidator();
+        $result = $extensionValidator->validateExtension($this->extension);
+
+        $warningCodes = array_map(fn($w) => $w->getCode(), $result['warnings']);
+        self::assertContains(
+            ExtensionValidator::ERROR_DOMAINOBJECT_NO_PROPERTIES,
+            $warningCodes,
+            'Expected warning for domain object without properties'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function validateConfigurationFormatReturnsExceptionsOnDuplicatePropertyNames(): void
     {
         $fixture = [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,7 +141,7 @@ parameters:
 		-
 			message: '#^Constant LF not found\.$#'
 			identifier: constant.notFound
-			count: 26
+			count: 28
 			path: Classes/Domain/Validator/ExtensionValidator.php
 
 		-


### PR DESCRIPTION
## Summary

Fixes #673.

When a domain object has no own properties but is the **target of a `ZeroToMany inline` relation**, the FK column for that relation must still appear in `ext_tables.sql`. The template condition in `extTables.sqlt` previously skipped the entire `CREATE TABLE` block in this case, silently dropping the FK column and leaving the database table uncreated.

A second, related problem: a model with truly no properties, no FK relations, and no type field would produce an empty `CREATE TABLE` statement (invalid SQL). Users are now warned about this via the validator.

### Changes

- **`Resources/Private/CodeTemplates/Extbase/extTables.sqlt`**: Extend the `<f:if>` condition to also check `listForeignKeyRelations` — ensures `CREATE TABLE` is generated when a model has incoming FK columns even with no own properties
- **`Classes/Domain/Validator/ExtensionValidator.php`**: Add `ERROR_DOMAINOBJECT_NO_PROPERTIES = 104` warning when a domain object has no properties, informing the user that no `CREATE TABLE` will be generated
- **`Tests/Functional/Service/FileGeneratorTest.php`**: New test verifying FK column appears in `ext_tables.sql` for a child model with no own properties
- **`Tests/Unit/Domain/Validator/ValidationServiceTest.php`**: New test for the validation warning
- **`phpstan-baseline.neon`**: Updated count for `LF` constant (2 additional usages)
- **`Documentation/ChangeLog/Index.rst`**: Changelog entries

## Test plan

- [x] Unit tests pass: `ValidationServiceTest::validateExtensionWarnsForDomainObjectWithNoProperties`
- [x] Functional test passes: `FileGeneratorTest::extTablesSqlContainsForeignKeyForChildModelWithNoProperties`
- [x] All existing unit tests green (152 tests)
- [x] All existing functional tests green (98 tests)
- [x] PHPStan: no errors
- [x] JS linter: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)