### PR TITLE
[TASK] Fix #719: Remove obsolete PHPDoc @return annotations

### DIFF
--- a/Classes/Controller/BuilderModuleController.php
+++ b/Classes/Controller/BuilderModuleController.php
@@ -272,8 +272,6 @@ class BuilderModuleController extends ActionController
 
     /**
      * Main entry point for the buttons in the Javascript frontend.
-     *
-     * @return ResponseInterface json encoded array
      */
     public function dispatchRpcAction(): ResponseInterface
     {
@@ -311,7 +309,6 @@ class BuilderModuleController extends ActionController
     /**
      * Generate the code files according to the transferred JSON configuration.
      *
-     * @return array (status => message)
      * @throws Exception
      */
     protected function rpcActionSave(): array
@@ -441,8 +438,6 @@ class BuilderModuleController extends ActionController
     /**
      * Shows a list with available extensions (if they have an ExtensionBuilder.json
      * file).
-     *
-     * @return array
      */
     protected function rpcActionList(): array
     {


### PR DESCRIPTION
## Summary

- Remove `@return ResponseInterface json encoded array` from `dispatchRpcAction()` — the description "json encoded array" is misleading; the PHP type hint already documents the return type
- Remove `@return array (status => message)` from `rpcActionSave()` — the description is outdated (actual return keys: `success`, `errors`, `warnings`, `warning`, `confirm`, `confirmFieldName`, `installationHints`); `@throws Exception` is kept
- Remove `@return array` from `rpcActionList()` — pure duplication of the PHP return type hint

Annotations that add value beyond the type hints (`@param Exception[] $warnings` and `@return array confirm...` on `handleValidationWarnings()`) are left untouched.

Closes #719

## Test plan

- [x] PHPStan passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)