### PR TITLE
[TASK] Fix #658: Generate user.tsconfig for backend module extensions

### DIFF
--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -172,6 +172,8 @@ class FileGenerator
 
         $this->generatePageTsConfig();
 
+        $this->generateUserTsConfig();
+
         $this->generateServicesYaml();
 
         $this->generateBackendModuleFiles();
@@ -287,6 +289,25 @@ class FileGenerator
     {
         // Plugin wizard entries are registered automatically by ExtensionUtility::registerPlugin()
         // when using PLUGIN_TYPE_CONTENT_ELEMENT, so no page.tsconfig generation is needed.
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function generateUserTsConfig(): void
+    {
+        if (!$this->extension->hasBackendModules()) {
+            return;
+        }
+        try {
+            $fileContents = $this->renderTemplate(
+                'Configuration/user.tsconfigt',
+                ['extension' => $this->extension]
+            );
+            $this->writeFile($this->configurationDirectory . 'user.tsconfig', $fileContents);
+        } catch (Exception $e) {
+            throw new Exception('Could not write Configuration/user.tsconfig. Error: ' . $e->getMessage());
+        }
     }
 
     /**

--- a/Resources/Private/CodeTemplates/Extbase/Configuration/user.tsconfigt
+++ b/Resources/Private/CodeTemplates/Extbase/Configuration/user.tsconfigt
@@ -1,0 +1,3 @@
+{namespace k=EBT\ExtensionBuilder\ViewHelpers}<f:for each="{extension.BackendModules}" as="backendModule">module.{extension.extensionKey}_{backendModule.key} {
+}
+</f:for>


### PR DESCRIPTION
## Summary

- Adds `generateUserTsConfig()` to `FileGenerator` — called after `generatePageTsConfig()`, skipped when the extension has no backend modules
- Adds `Configuration/user.tsconfigt` template generating a `module.{extensionKey}_{moduleKey} {}` block per backend module as a starting point for developers

In TYPO3 v13, `Configuration/user.tsconfig` is automatically loaded for all backend users ([Feature #101807](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Feature-101807-AutomaticInclusionOfUserTSconfigOfExtensions.html)), replacing the deprecated `ExtensionManagementUtility::addUserTSConfig()`.

Closes #658

## Test plan

- [x] Generate an extension with at least one backend module → `Configuration/user.tsconfig` is created with a `module.{key} {}` block per module
- [x] Generate an extension with only frontend plugins (no backend modules) → no `user.tsconfig` is generated
- [x] PHPStan: no new errors
- [x] Unit and Functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)