### PR TITLE
[BUGFIX] Use image attribute in f:image ViewHelper to fix Umlaut/special char filenames

### DIFF
--- a/Resources/Private/CodeTemplates/Extbase/Partials/Property.htmlt
+++ b/Resources/Private/CodeTemplates/Extbase/Partials/Property.htmlt
@@ -3,11 +3,11 @@
 		<f:if condition="{property.zeroToManyRelation}">
 			<f:then>
             <k:openingTag>f:for each="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}.{property.name}</k:curlyBrackets>" as="image" </k:openingTag>
-                <k:openingTag>f:image src="<k:curlyBrackets>image.originalResource.publicUrl</k:curlyBrackets>" width="200"/</k:openingTag>
+                <k:openingTag>f:image image="<k:curlyBrackets>image</k:curlyBrackets>" width="200"/</k:openingTag>
             <k:openingTag>/f:for</k:openingTag>
         </f:then>
             <f:else>
-				<k:openingTag>f:image src="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}.{property.name}.originalResource.publicUrl</k:curlyBrackets>" width="200"/</k:openingTag>
+				<k:openingTag>f:image image="<k:curlyBrackets>{domainObject.name -> k:format.lowercaseFirst()}.{property.name}</k:curlyBrackets>" width="200"/</k:openingTag>
             </f:else>
         </f:if></f:case>
 	<f:case value="File">

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/AstroImage/Properties.html
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/AstroImage/Properties.html
@@ -15,7 +15,7 @@
 	<tr>
 		<td><f:translate key="tx_ebastrophotography_domain_model_astroimage.image" /></td>
 		<td>
-				<f:image src="{astroImage.image.originalResource.publicUrl}" width="200"/>
+				<f:image image="{astroImage.image}" width="200"/>
             </td>
 	</tr>
 	<tr>

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/CelestialObject/Properties.html
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/CelestialObject/Properties.html
@@ -39,7 +39,7 @@
 	<tr>
 		<td><f:translate key="tx_ebastrophotography_domain_model_celestialobject.preview_image" /></td>
 		<td>
-				<f:image src="{celestialObject.previewImage.originalResource.publicUrl}" width="200"/>
+				<f:image image="{celestialObject.previewImage}" width="200"/>
             </td>
 	</tr>
 	<tr>

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/ObservingSite/Properties.html
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/ObservingSite/Properties.html
@@ -39,7 +39,7 @@
 	<tr>
 		<td><f:translate key="tx_ebastrophotography_domain_model_observingsite.image" /></td>
 		<td>
-				<f:image src="{observingSite.image.originalResource.publicUrl}" width="200"/>
+				<f:image image="{observingSite.image}" width="200"/>
             </td>
 	</tr>
 </table>

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/Telescope/Properties.html
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Resources/Private/Partials/Telescope/Properties.html
@@ -39,7 +39,7 @@
 	<tr>
 		<td><f:translate key="tx_ebastrophotography_domain_model_telescope.image" /></td>
 		<td>
-				<f:image src="{telescope.image.originalResource.publicUrl}" width="200"/>
+				<f:image image="{telescope.image}" width="200"/>
             </td>
 	</tr>
 </table>


### PR DESCRIPTION
## Problem

When a domain model property of type `Image` is used, the Extension Builder generates templates like:

```html
<f:image src="{object.image.originalResource.publicUrl}" width="200"/>
```

The `publicUrl` is percent-encoded (e.g. `/fileadmin/t%C3%A4st.jpeg`), which fails when the web server resolves the path to an actual file like `/fileadmin/täst.jpeg`.

Fixes #563

## Solution

Use the `image` attribute of the `f:image` ViewHelper instead of `src` with a public URL:

```html
<f:image image="{object.image}" width="200"/>
```

This passes the FAL `FileReference` object directly to the ViewHelper, which handles the FAL API correctly — no URL-encoding issues.

## Changes

- `Resources/Private/CodeTemplates/Extbase/Partials/Property.htmlt` — updated template for single and `zeroToMany` image properties
- Fixture files updated to reflect the new generated output

## Notes

File link templates (`href="{...originalResource.publicUrl}"`) have the same underlying issue but are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)