### PR TITLE
[BUGFIX] Fix #785: Change SelectProperty type from int to string

### DIFF
--- a/Classes/Domain/Model/DomainObject/SelectProperty.php
+++ b/Classes/Domain/Model/DomainObject/SelectProperty.php
@@ -22,22 +22,22 @@ class SelectProperty extends AbstractProperty
     /**
      * the property's default value
      *
-     * @var int
+     * @var string
      */
-    protected $defaultValue = 0;
+    protected $defaultValue = '';
 
     public function getTypeForComment(): string
     {
-        return 'int';
+        return 'string';
     }
 
     public function getTypeHint(): string
     {
-        return 'int';
+        return 'string';
     }
 
     public function getSqlDefinition(): string
     {
-        return $this->getFieldName() . " int(11) DEFAULT '0' NOT NULL,";
+        return $this->getFieldName() . " varchar(255) NOT NULL DEFAULT '',";
     }
 }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/AstroFilter.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/AstroFilter.php
@@ -32,9 +32,9 @@ class AstroFilter extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * filterType
      *
-     * @var int
+     * @var string
      */
-    protected $filterType = 0;
+    protected $filterType = '';
 
     /**
      * centralWavelength
@@ -102,7 +102,7 @@ class AstroFilter extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the filterType
      *
-     * @return int
+     * @return string
      */
     public function getFilterType()
     {
@@ -112,10 +112,10 @@ class AstroFilter extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the filterType
      *
-     * @param int $filterType
+     * @param string $filterType
      * @return void
      */
-    public function setFilterType(int $filterType)
+    public function setFilterType(string $filterType)
     {
         $this->filterType = $filterType;
     }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/Camera.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/Camera.php
@@ -39,9 +39,9 @@ class Camera extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * sensorType
      *
-     * @var int
+     * @var string
      */
-    protected $sensorType = 0;
+    protected $sensorType = '';
 
     /**
      * sensorWidth
@@ -137,7 +137,7 @@ class Camera extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the sensorType
      *
-     * @return int
+     * @return string
      */
     public function getSensorType()
     {
@@ -147,10 +147,10 @@ class Camera extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the sensorType
      *
-     * @param int $sensorType
+     * @param string $sensorType
      * @return void
      */
-    public function setSensorType(int $sensorType)
+    public function setSensorType(string $sensorType)
     {
         $this->sensorType = $sensorType;
     }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/CelestialObject.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/CelestialObject.php
@@ -39,9 +39,9 @@ class CelestialObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * objectType
      *
-     * @var int
+     * @var string
      */
-    protected $objectType = 0;
+    protected $objectType = '';
 
     /**
      * constellation
@@ -145,7 +145,7 @@ class CelestialObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the objectType
      *
-     * @return int
+     * @return string
      */
     public function getObjectType()
     {
@@ -155,10 +155,10 @@ class CelestialObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the objectType
      *
-     * @param int $objectType
+     * @param string $objectType
      * @return void
      */
-    public function setObjectType(int $objectType)
+    public function setObjectType(string $objectType)
     {
         $this->objectType = $objectType;
     }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/ProcessingRecipe.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/ProcessingRecipe.php
@@ -46,9 +46,9 @@ class ProcessingRecipe extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * stackingMethod
      *
-     * @var int
+     * @var string
      */
-    protected $stackingMethod = 0;
+    protected $stackingMethod = '';
 
     /**
      * totalIntegrationTime
@@ -181,7 +181,7 @@ class ProcessingRecipe extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the stackingMethod
      *
-     * @return int
+     * @return string
      */
     public function getStackingMethod()
     {
@@ -191,10 +191,10 @@ class ProcessingRecipe extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the stackingMethod
      *
-     * @param int $stackingMethod
+     * @param string $stackingMethod
      * @return void
      */
-    public function setStackingMethod(int $stackingMethod)
+    public function setStackingMethod(string $stackingMethod)
     {
         $this->stackingMethod = $stackingMethod;
     }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/Telescope.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Classes/Domain/Model/Telescope.php
@@ -39,9 +39,9 @@ class Telescope extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * telescopeType
      *
-     * @var int
+     * @var string
      */
-    protected $telescopeType = 0;
+    protected $telescopeType = '';
 
     /**
      * focalLength
@@ -138,7 +138,7 @@ class Telescope extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the telescopeType
      *
-     * @return int
+     * @return string
      */
     public function getTelescopeType()
     {
@@ -148,10 +148,10 @@ class Telescope extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the telescopeType
      *
-     * @param int $telescopeType
+     * @param string $telescopeType
      * @return void
      */
-    public function setTelescopeType(int $telescopeType)
+    public function setTelescopeType(string $telescopeType)
     {
         $this->telescopeType = $telescopeType;
     }

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/AstroFilterTest.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/AstroFilterTest.php
@@ -57,10 +57,10 @@ class AstroFilterTest extends UnitTestCase
     /**
      * @test
      */
-    public function getFilterTypeReturnsInitialValueForInt(): void
+    public function getFilterTypeReturnsInitialValueForString(): void
     {
         self::assertSame(
-            0,
+            '',
             $this->subject->getFilterType()
         );
     }
@@ -68,11 +68,11 @@ class AstroFilterTest extends UnitTestCase
     /**
      * @test
      */
-    public function setFilterTypeForIntSetsFilterType(): void
+    public function setFilterTypeForStringSetsFilterType(): void
     {
-        $this->subject->setFilterType(12);
+        $this->subject->setFilterType('Conceived at T3CON10');
 
-        self::assertEquals(12, $this->subject->_get('filterType'));
+        self::assertEquals('Conceived at T3CON10', $this->subject->_get('filterType'));
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/CameraTest.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/CameraTest.php
@@ -78,10 +78,10 @@ class CameraTest extends UnitTestCase
     /**
      * @test
      */
-    public function getSensorTypeReturnsInitialValueForInt(): void
+    public function getSensorTypeReturnsInitialValueForString(): void
     {
         self::assertSame(
-            0,
+            '',
             $this->subject->getSensorType()
         );
     }
@@ -89,11 +89,11 @@ class CameraTest extends UnitTestCase
     /**
      * @test
      */
-    public function setSensorTypeForIntSetsSensorType(): void
+    public function setSensorTypeForStringSetsSensorType(): void
     {
-        $this->subject->setSensorType(12);
+        $this->subject->setSensorType('Conceived at T3CON10');
 
-        self::assertEquals(12, $this->subject->_get('sensorType'));
+        self::assertEquals('Conceived at T3CON10', $this->subject->_get('sensorType'));
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/CelestialObjectTest.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/CelestialObjectTest.php
@@ -78,10 +78,10 @@ class CelestialObjectTest extends UnitTestCase
     /**
      * @test
      */
-    public function getObjectTypeReturnsInitialValueForInt(): void
+    public function getObjectTypeReturnsInitialValueForString(): void
     {
         self::assertSame(
-            0,
+            '',
             $this->subject->getObjectType()
         );
     }
@@ -89,11 +89,11 @@ class CelestialObjectTest extends UnitTestCase
     /**
      * @test
      */
-    public function setObjectTypeForIntSetsObjectType(): void
+    public function setObjectTypeForStringSetsObjectType(): void
     {
-        $this->subject->setObjectType(12);
+        $this->subject->setObjectType('Conceived at T3CON10');
 
-        self::assertEquals(12, $this->subject->_get('objectType'));
+        self::assertEquals('Conceived at T3CON10', $this->subject->_get('objectType'));
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/ProcessingRecipeTest.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/ProcessingRecipeTest.php
@@ -99,10 +99,10 @@ class ProcessingRecipeTest extends UnitTestCase
     /**
      * @test
      */
-    public function getStackingMethodReturnsInitialValueForInt(): void
+    public function getStackingMethodReturnsInitialValueForString(): void
     {
         self::assertSame(
-            0,
+            '',
             $this->subject->getStackingMethod()
         );
     }
@@ -110,11 +110,11 @@ class ProcessingRecipeTest extends UnitTestCase
     /**
      * @test
      */
-    public function setStackingMethodForIntSetsStackingMethod(): void
+    public function setStackingMethodForStringSetsStackingMethod(): void
     {
-        $this->subject->setStackingMethod(12);
+        $this->subject->setStackingMethod('Conceived at T3CON10');
 
-        self::assertEquals(12, $this->subject->_get('stackingMethod'));
+        self::assertEquals('Conceived at T3CON10', $this->subject->_get('stackingMethod'));
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/TelescopeTest.php
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/Tests/Unit/Domain/Model/TelescopeTest.php
@@ -78,10 +78,10 @@ class TelescopeTest extends UnitTestCase
     /**
      * @test
      */
-    public function getTelescopeTypeReturnsInitialValueForInt(): void
+    public function getTelescopeTypeReturnsInitialValueForString(): void
     {
         self::assertSame(
-            0,
+            '',
             $this->subject->getTelescopeType()
         );
     }
@@ -89,11 +89,11 @@ class TelescopeTest extends UnitTestCase
     /**
      * @test
      */
-    public function setTelescopeTypeForIntSetsTelescopeType(): void
+    public function setTelescopeTypeForStringSetsTelescopeType(): void
     {
-        $this->subject->setTelescopeType(12);
+        $this->subject->setTelescopeType('Conceived at T3CON10');
 
-        self::assertEquals(12, $this->subject->_get('telescopeType'));
+        self::assertEquals('Conceived at T3CON10', $this->subject->_get('telescopeType'));
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/eb_astrophotography/ext_tables.sql
+++ b/Tests/Fixtures/TestExtensions/eb_astrophotography/ext_tables.sql
@@ -14,7 +14,7 @@ CREATE TABLE tx_ebastrophotography_domain_model_astroimage (
 CREATE TABLE tx_ebastrophotography_domain_model_celestialobject (
 	name varchar(255) NOT NULL DEFAULT '',
 	catalog_id varchar(255) NOT NULL DEFAULT '',
-	object_type int(11) DEFAULT '0' NOT NULL,
+	object_type varchar(255) NOT NULL DEFAULT '',
 	constellation varchar(255) NOT NULL DEFAULT '',
 	right_ascension varchar(255) NOT NULL DEFAULT '',
 	declination varchar(255) NOT NULL DEFAULT '',
@@ -28,7 +28,7 @@ CREATE TABLE tx_ebastrophotography_domain_model_celestialobject (
 CREATE TABLE tx_ebastrophotography_domain_model_telescope (
 	name varchar(255) NOT NULL DEFAULT '',
 	brand varchar(255) NOT NULL DEFAULT '',
-	telescope_type int(11) DEFAULT '0' NOT NULL,
+	telescope_type varchar(255) NOT NULL DEFAULT '',
 	focal_length int(11) NOT NULL DEFAULT '0',
 	aperture int(11) NOT NULL DEFAULT '0',
 	focal_ratio double(11,2) NOT NULL DEFAULT '0.00',
@@ -41,7 +41,7 @@ CREATE TABLE tx_ebastrophotography_domain_model_telescope (
 CREATE TABLE tx_ebastrophotography_domain_model_camera (
 	name varchar(255) NOT NULL DEFAULT '',
 	brand varchar(255) NOT NULL DEFAULT '',
-	sensor_type int(11) DEFAULT '0' NOT NULL,
+	sensor_type varchar(255) NOT NULL DEFAULT '',
 	sensor_width double(11,2) NOT NULL DEFAULT '0.00',
 	sensor_height double(11,2) NOT NULL DEFAULT '0.00',
 	pixel_size double(11,2) NOT NULL DEFAULT '0.00',
@@ -53,7 +53,7 @@ CREATE TABLE tx_ebastrophotography_domain_model_camera (
 
 CREATE TABLE tx_ebastrophotography_domain_model_astrofilter (
 	name varchar(255) NOT NULL DEFAULT '',
-	filter_type int(11) DEFAULT '0' NOT NULL,
+	filter_type varchar(255) NOT NULL DEFAULT '',
 	central_wavelength int(11) NOT NULL DEFAULT '0',
 	bandwidth double(11,2) NOT NULL DEFAULT '0.00',
 	color varchar(7) NOT NULL DEFAULT '',
@@ -97,7 +97,7 @@ CREATE TABLE tx_ebastrophotography_domain_model_processingrecipe (
 	title varchar(255) NOT NULL DEFAULT '',
 	software varchar(255) NOT NULL DEFAULT '',
 	description text,
-	stacking_method int(11) DEFAULT '0' NOT NULL,
+	stacking_method varchar(255) NOT NULL DEFAULT '',
 	total_integration_time double(11,2) NOT NULL DEFAULT '0.00',
 	processing_date datetime DEFAULT NULL,
 	

--- a/Tests/Functional/FileGenerator/Property/GeneratedPropertyTest.php
+++ b/Tests/Functional/FileGenerator/Property/GeneratedPropertyTest.php
@@ -920,13 +920,13 @@ class GeneratedPropertyTest extends BaseFunctionalTest
         $classFileContent = $this->fileGenerator->generateDomainObjectCode($domainObject);
 
         self::assertMatchesRegularExpression(
-            '/.*\* @var int.*/',
+            '/.*\* @var string.*/',
             $classFileContent,
             'var tag for select property was not generated'
         );
 
         self::assertMatchesRegularExpression(
-            '/.*protected \\$color = 0;.*/',
+            "/.*protected \\\$color = '';.*/",
             $classFileContent,
             'select property was not generated'
         );
@@ -937,7 +937,7 @@ class GeneratedPropertyTest extends BaseFunctionalTest
             'Getter for select property was not generated'
         );
         self::assertMatchesRegularExpression(
-            '/.*public function setColor\(int \$color\).*/',
+            '/.*public function setColor\(string \$color\).*/',
             $classFileContent,
             'Setter for select property was not generated'
         );

--- a/Tests/Unit/Domain/Model/DomainObject/SelectPropertySqlTest.php
+++ b/Tests/Unit/Domain/Model/DomainObject/SelectPropertySqlTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace EBT\ExtensionBuilder\Tests\Unit\Domain\Model\DomainObject;
+
+use EBT\ExtensionBuilder\Domain\Model\DomainObject\SelectProperty;
+use EBT\ExtensionBuilder\Tests\BaseUnitTest;
+
+/**
+ * Select properties are stored as varchar(255) in TYPO3, consistent with
+ * the TCA type=select schema and the fact that item values can be strings.
+ */
+class SelectPropertySqlTest extends BaseUnitTest
+{
+    /**
+     * @test
+     */
+    public function selectPropertyReturnsVarcharSqlDefinition(): void
+    {
+        $property = new SelectProperty();
+        $property->setName('status');
+        $property->setDomainObject($this->buildDomainObject('TestModel'));
+
+        self::assertSame(
+            "status varchar(255) NOT NULL DEFAULT '',",
+            $property->getSqlDefinition()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function selectPropertyTypeForCommentIsString(): void
+    {
+        $property = new SelectProperty();
+        self::assertSame('string', $property->getTypeForComment());
+    }
+
+    /**
+     * @test
+     */
+    public function selectPropertyTypeHintIsString(): void
+    {
+        $property = new SelectProperty();
+        self::assertSame('string', $property->getTypeHint());
+    }
+}

--- a/Tests/Unit/Service/ClassBuilderTest.php
+++ b/Tests/Unit/Service/ClassBuilderTest.php
@@ -195,7 +195,7 @@ class ClassBuilderTest extends BaseUnitTest
             'nativeDateTime' => ['nativeDateTime', null],
             'password' => ['password', ''],
             'richText' => ['richText', ''],
-            'select' => ['select', 0],
+            'select' => ['select', ''],
             'string' => ['string', ''],
             'text' => ['text', ''],
             'nativeTime' => ['nativeTime', null],


### PR DESCRIPTION
## Summary

- `SelectProperty` generated `int` type hint and `int(11)` SQL, but TYPO3 stores `type=select` field values as `varchar(255)`
- This caused a type mismatch in the TYPO3 DB Analyzer and runtime errors when select items have string values (e.g. `'draft'`, `'published'`)
- Changed `SelectProperty` to use `string` type and `varchar(255)` SQL — consistent with `StringProperty` and TYPO3 TCA behavior

## Changes

- `Classes/Domain/Model/DomainObject/SelectProperty.php` — `int` → `string`, `int(11)` → `varchar(255)`, default `0` → `''`
- `Tests/Functional/FileGenerator/Property/GeneratedPropertyTest.php` — updated assertions to match new string type
- `Tests/Unit/Domain/Model/DomainObject/SelectPropertySqlTest.php` — new unit tests for SQL definition and type methods
- `Tests/Unit/Service/ClassBuilderTest.php` — updated `classBuilderGeneratesPropertyDefault` data set for select from `0` to `''`
- `Tests/Fixtures/TestExtensions/eb_astrophotography/ext_tables.sql` — updated 5 select fields from `int(11) DEFAULT '0' NOT NULL` to `varchar(255) NOT NULL DEFAULT ''`

## Test plan

- [x] New unit tests pass: `SelectPropertySqlTest` (3 tests)
- [x] Existing functional test passes: `writeModelClassWithSelectProperty`
- [x] `classBuilderGeneratesPropertyDefault` passes with updated select default
- [x] `generateExtensionFromAstrophotographyConfiguration` passes with updated fixture SQL

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)