### PR TITLE
[BUGFIX] #796: Preserve field description case in localization files

### DIFF
--- a/Classes/Service/LocalizationService.php
+++ b/Classes/Service/LocalizationService.php
@@ -62,10 +62,10 @@ class LocalizationService implements SingletonInterface
         foreach ($extension->getDomainObjects() as $domainObject) {
             /* @var DomainObject $domainObject */
             $labelArray[$domainObject->getLabelNamespace()] = Inflector::humanize($domainObject->getName());
-            $labelArray[$domainObject->getDescriptionNamespace()] = Inflector::humanize($domainObject->getDescription());
+            $labelArray[$domainObject->getDescriptionNamespace()] = $domainObject->getDescription();
             foreach ($domainObject->getProperties() as $property) {
                 $labelArray[$property->getLabelNamespace()] = Inflector::humanize($property->getName());
-                $labelArray[$property->getDescriptionNamespace()] = Inflector::humanize($property->getDescription());
+                $labelArray[$property->getDescriptionNamespace()] = $property->getDescription();
             }
             if ($type === 'locallang_db.xlf') {
                 $tableToMapTo = $domainObject->getMapToTable();

--- a/Tests/Unit/Service/LocalizationServiceTest.php
+++ b/Tests/Unit/Service/LocalizationServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace EBT\ExtensionBuilder\Tests\Unit\Service;
+
+use EBT\ExtensionBuilder\Domain\Model\DomainObject\StringProperty;
+use EBT\ExtensionBuilder\Service\LocalizationService;
+use EBT\ExtensionBuilder\Tests\BaseUnitTest;
+use TYPO3\CMS\Core\Localization\Parser\XliffParser;
+
+class LocalizationServiceTest extends BaseUnitTest
+{
+    protected LocalizationService $localizationService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->localizationService = new LocalizationService();
+        $this->localizationService->injectXliffParser($this->createMock(XliffParser::class));
+    }
+
+    /**
+     * @test
+     */
+    public function prepareLabelArrayPreservesDescriptionCaseForProperties(): void
+    {
+        $domainObject = $this->buildDomainObject('MyModel', true);
+        $domainObject->setDescription('domain object description');
+
+        $property = new StringProperty();
+        $property->setName('myField');
+        $property->setDescription('this should stay lowercase and not Be ucworded');
+        $domainObject->addProperty($property);
+
+        $this->extension->addDomainObject($domainObject);
+
+        $labelArray = $this->localizationService->prepareLabelArray($this->extension);
+
+        self::assertSame(
+            'this should stay lowercase and not Be ucworded',
+            $labelArray[$property->getDescriptionNamespace()]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function prepareLabelArrayPreservesDescriptionCaseForDomainObjects(): void
+    {
+        $domainObject = $this->buildDomainObject('MyModel', true);
+        $domainObject->setDescription('lower case domain description — preserve this');
+
+        $this->extension->addDomainObject($domainObject);
+
+        $labelArray = $this->localizationService->prepareLabelArray($this->extension);
+
+        self::assertSame(
+            'lower case domain description — preserve this',
+            $labelArray[$domainObject->getDescriptionNamespace()]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function prepareLabelArrayStillHumanizesNames(): void
+    {
+        $domainObject = $this->buildDomainObject('myModel', true);
+
+        $property = new StringProperty();
+        $property->setName('myField');
+        $domainObject->addProperty($property);
+
+        $this->extension->addDomainObject($domainObject);
+
+        $labelArray = $this->localizationService->prepareLabelArray($this->extension);
+
+        self::assertSame('My Model', $labelArray[$domainObject->getLabelNamespace()]);
+        self::assertSame('My Field', $labelArray[$property->getLabelNamespace()]);
+    }
+}


### PR DESCRIPTION
## Problem

Field descriptions entered in the Extension Builder GUI were incorrectly processed through `Inflector::humanize()` before being written to XLF language files. This function applies `ucwords()`-style capitalization to every word, corrupting user-entered text.

Example: a description like `"this is a custom field"` was written as `"This Is A Custom Field"`.

## Root cause

In `LocalizationService::prepareLabelArray()`, both domain object and property descriptions were passed through `Inflector::humanize()`:

```php
// Before (wrong):
$labelArray[$domainObject->getDescriptionNamespace()] = Inflector::humanize($domainObject->getDescription());
$labelArray[$property->getDescriptionNamespace()] = Inflector::humanize($property->getDescription());
```

`Inflector::humanize()` is appropriate for auto-generated *labels* derived from PHP identifiers (e.g. `myFieldName` → `My Field Name`), but descriptions are free text that must be preserved verbatim.

## Fix

Pass descriptions directly without transformation:

```php
// After (correct):
$labelArray[$domainObject->getDescriptionNamespace()] = $domainObject->getDescription();
$labelArray[$property->getDescriptionNamespace()] = $property->getDescription();
```

Names (labels) continue to use `Inflector::humanize()` as before.

## Tests

Added `Tests/Unit/Service/LocalizationServiceTest.php` with three test cases:
- Property descriptions are preserved verbatim
- Domain object descriptions are preserved verbatim
- Names (labels) are still humanized (regression guard)

Fixes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)