### PR TITLE
[BUGFIX] Fix #793: Undefined array key "excludeField" in ObjectSchemaBuilder

### DIFF
--- a/Classes/Service/ObjectSchemaBuilder.php
+++ b/Classes/Service/ObjectSchemaBuilder.php
@@ -157,7 +157,7 @@ class ObjectSchemaBuilder implements SingletonInterface
         $relation->setName($relationJsonConfiguration['relationName']);
         $relation->setLazyLoading((bool)($relationJsonConfiguration['lazyLoading'] ?? false));
         $relation->setNullable((bool)($relationJsonConfiguration['propertyIsNullable'] ?? false));
-        $relation->setExcludeField((bool)$relationJsonConfiguration['propertyIsExcludeField']);
+        $relation->setExcludeField((bool)($relationJsonConfiguration['propertyIsExcludeField'] ?? false));
         $relation->setDescription($relationJsonConfiguration['relationDescription'] ?? '');
         $relation->setUniqueIdentifier($relationJsonConfiguration['uid'] ?? '');
         $relation->setType($relationJsonConfiguration['type'] ?? '');

--- a/Tests/Unit/Service/ObjectSchemaBuilderTest.php
+++ b/Tests/Unit/Service/ObjectSchemaBuilderTest.php
@@ -175,6 +175,43 @@ class ObjectSchemaBuilderTest extends BaseUnitTest
     /**
      * @test
      */
+    public function buildRelationWithMissingExcludeFieldDefaultsToFalse(): void
+    {
+        $className = '\\TYPO3\\CMS\\Extbase\\Domain\\Model\\FrontendUser';
+
+        $input = [
+            'name' => 'MyDomainObject',
+            'objectsettings' => [
+                'description' => '',
+                'aggregateRoot' => false,
+                'type' => 'Entity',
+            ],
+            'relationGroup' => [
+                'relations' => [
+                    0 => [
+                        'relationName' => 'relation without excludeField',
+                        'relationType' => 'manyToMany',
+                        // propertyIsExcludeField intentionally omitted to test regression
+                        'foreignRelationClass' => $className,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configurationManager->expects(self::atLeastOnce())
+            ->method('getPersistenceTable')
+            ->with($className)
+            ->willReturn('fe_users');
+
+        $domainObject = $this->objectSchemaBuilder->build($input);
+        $properties = $domainObject->getProperties();
+        self::assertCount(1, $properties);
+        self::assertFalse($properties[0]->getExcludeField(), 'excludeField should default to false when missing from JSON');
+    }
+
+    /**
+     * @test
+     */
     public function manyToManyRelationReturnsCorrectRelationTable(): void
     {
         $name = 'MyDomainObject';


### PR DESCRIPTION
## Problem

When saving an extension with two domain objects connected by a relation, the save fails with:

```
PHP Warning: Undefined array key "excludeField" in ObjectSchemaBuilder.php
```

The `propertyIsExcludeField` key may be absent from the JSON payload (e.g. when a relation is freshly created and not yet fully configured). Direct array access without an existence check caused the warning.

## Solution

Add a `?? false` null-coalescing fallback on line 160 of `ObjectSchemaBuilder::buildRelation()`, consistent with the neighboring lines that already use this pattern for `lazyLoading` and `propertyIsNullable`.

```php
// Before
$relation->setExcludeField((bool)$relationJsonConfiguration['propertyIsExcludeField']);

// After
$relation->setExcludeField((bool)($relationJsonConfiguration['propertyIsExcludeField'] ?? false));
```

## Changes

- `Classes/Service/ObjectSchemaBuilder.php` — one-line fix
- `Tests/Unit/Service/ObjectSchemaBuilderTest.php` — regression test covering the missing-key scenario

Fixes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)