### PR TITLE
[BUGFIX] Fix #627: Handle missing renderType in old ExtensionBuilder.json files

### DIFF
--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -293,7 +293,7 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
                         $module['value']['relationGroup']['relations'][$i]['advancedSettings'] = [];
                         foreach ($fieldsToMap as $fieldToMap) {
                             $module['value']['relationGroup']['relations'][$i]['advancedSettings'][$fieldToMap] =
-                                $module['value']['relationGroup']['relations'][$i][$fieldToMap];
+                                $module['value']['relationGroup']['relations'][$i][$fieldToMap] ?? null;
                         }
 
                         $module['value']['relationGroup']['relations'][$i]['advancedSettings']['propertyIsExcludeField'] =
@@ -308,7 +308,7 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
                 } elseif (isset($module['value']['relationGroup']['relations'][$i]['advancedSettings'])) {
                     foreach ($fieldsToMap as $fieldToMap) {
                         $module['value']['relationGroup']['relations'][$i][$fieldToMap] =
-                            $module['value']['relationGroup']['relations'][$i]['advancedSettings'][$fieldToMap];
+                            $module['value']['relationGroup']['relations'][$i]['advancedSettings'][$fieldToMap] ?? null;
                     }
                     unset($module['value']['relationGroup']['relations'][$i]['advancedSettings']);
                 }

--- a/Tests/Unit/Configuration/ExtensionBuilderConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/ExtensionBuilderConfigurationManagerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace EBT\ExtensionBuilder\Tests\Unit\Configuration;
+
+use EBT\ExtensionBuilder\Configuration\ExtensionBuilderConfigurationManager;
+use EBT\ExtensionBuilder\Tests\BaseUnitTest;
+
+class ExtensionBuilderConfigurationManagerTest extends BaseUnitTest
+{
+    private ExtensionBuilderConfigurationManager $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = $this->getAccessibleMock(
+            ExtensionBuilderConfigurationManager::class,
+            null,
+            [],
+            '',
+            false
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mapAdvancedModeToleratesRelationWithoutRenderType(): void
+    {
+        $jsonConfig = [
+            [
+                'value' => [
+                    'relationGroup' => [
+                        'relations' => [
+                            [
+                                'relationType' => 'manyToOne',
+                                'propertyIsExcludeField' => true,
+                                'lazyLoading' => false,
+                                'relationDescription' => '',
+                                'foreignRelationClass' => '',
+                                // renderType intentionally omitted — old ExtensionBuilder.json
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->subject->_call('mapAdvancedMode', $jsonConfig, true);
+
+        self::assertArrayHasKey('renderType', $result[0]['value']['relationGroup']['relations'][0]['advancedSettings']);
+        self::assertNull($result[0]['value']['relationGroup']['relations'][0]['advancedSettings']['renderType']);
+    }
+
+    /**
+     * @test
+     */
+    public function mapAdvancedModeBackwardToleratesMissingAdvancedSettingsKey(): void
+    {
+        $jsonConfig = [
+            [
+                'value' => [
+                    'relationGroup' => [
+                        'relations' => [
+                            [
+                                'relationType' => 'manyToOne',
+                                'advancedSettings' => [
+                                    'relationType' => 'manyToOne',
+                                    'propertyIsExcludeField' => true,
+                                    'lazyLoading' => false,
+                                    'relationDescription' => '',
+                                    'foreignRelationClass' => '',
+                                    // renderType intentionally omitted from advancedSettings
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->subject->_call('mapAdvancedMode', $jsonConfig, false);
+
+        self::assertArrayHasKey('renderType', $result[0]['value']['relationGroup']['relations'][0]);
+        self::assertNull($result[0]['value']['relationGroup']['relations'][0]['renderType']);
+    }
+}

--- a/Tests/Unit/Configuration/ExtensionBuilderConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/ExtensionBuilderConfigurationManagerTest.php
@@ -70,7 +70,7 @@ class ExtensionBuilderConfigurationManagerTest extends BaseUnitTest
     /**
      * @test
      */
-    public function mapAdvancedModeBackwardToleratesMissingAdvancedSettingsKey(): void
+    public function mapAdvancedModeBackwardToleratesRelationWithoutRenderType(): void
     {
         $jsonConfig = [
             [


### PR DESCRIPTION
## Problem

Old `ExtensionBuilder.json` files may contain relations without a `renderType` key. When loading such an extension, `ExtensionBuilderConfigurationManager::mapAdvancedMode()` accesses the array key directly, causing a PHP 8+ warning:

> PHP Warning: Undefined array key "renderType" in `ExtensionBuilderConfigurationManager.php`

This affects any user upgrading from an older Extension Builder version with existing JSON files.

## Solution

Add `?? null` null-coalescing fallbacks when reading fields from relations in both the forward mapping (`prepareForModeler=true`) and backward mapping (`prepareForModeler=false`) paths. This mirrors the fix applied for `excludeField` in #793.

## Changes

- `Classes/Configuration/ExtensionBuilderConfigurationManager.php`: Two-line fix with `?? null` fallback in `mapAdvancedMode()`
- `Tests/Unit/Configuration/ExtensionBuilderConfigurationManagerTest.php`: New test class covering both mapping directions with a relation missing `renderType`

## Test

```bash
.Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit/Configuration/
```

Fixes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)