### PR TITLE
[BUGFIX] Fix #677: Remove duplicate field and redundant assignments in mapAdvancedMode

### DIFF
--- a/Classes/Configuration/ExtensionBuilderConfigurationManager.php
+++ b/Classes/Configuration/ExtensionBuilderConfigurationManager.php
@@ -281,7 +281,6 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
             'relationType',
             'renderType',
             'propertyIsExcludeField',
-            'propertyIsExcludeField',
             'lazyLoading',
             'relationDescription',
             'foreignRelationClass',
@@ -295,15 +294,6 @@ class ExtensionBuilderConfigurationManager implements SingletonInterface
                             $module['value']['relationGroup']['relations'][$i]['advancedSettings'][$fieldToMap] =
                                 $module['value']['relationGroup']['relations'][$i][$fieldToMap] ?? null;
                         }
-
-                        $module['value']['relationGroup']['relations'][$i]['advancedSettings']['propertyIsExcludeField'] =
-                            $module['value']['relationGroup']['relations'][$i]['propertyIsExcludeField'];
-                        $module['value']['relationGroup']['relations'][$i]['advancedSettings']['lazyLoading'] =
-                            $module['value']['relationGroup']['relations'][$i]['lazyLoading'];
-                        $module['value']['relationGroup']['relations'][$i]['advancedSettings']['relationDescription'] =
-                            $module['value']['relationGroup']['relations'][$i]['relationDescription'];
-                        $module['value']['relationGroup']['relations'][$i]['advancedSettings']['foreignRelationClass'] =
-                            $module['value']['relationGroup']['relations'][$i]['foreignRelationClass'];
                     }
                 } elseif (isset($module['value']['relationGroup']['relations'][$i]['advancedSettings'])) {
                     foreach ($fieldsToMap as $fieldToMap) {


### PR DESCRIPTION
## Summary

- Removes duplicate `propertyIsExcludeField` entry from `$fieldsToMap` array in `mapAdvancedMode()`
- Removes four redundant explicit assignments after the `foreach` loop that overwrote the correctly null-coalesced values without `?? null` guards, potentially causing PHP warnings on old `ExtensionBuilder.json` files with missing keys

## Background

The core PHP warning fix for missing `renderType` was already applied in #834. However, `mapAdvancedMode()` still contained:
1. A duplicate `propertyIsExcludeField` entry in `$fieldsToMap`
2. Four explicit field assignments after the `foreach` loop (for `propertyIsExcludeField`, `lazyLoading`, `relationDescription`, `foreignRelationClass`) without `?? null` — overwriting the safely guarded values from the loop and potentially triggering PHP warnings when loading old extensions that lack those keys

The `foreach` loop already handles all these fields correctly with `?? null`, making the subsequent explicit assignments fully redundant.

## Test plan

- [x] Verify existing unit tests pass: `.Build/bin/phpunit --colors -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit`
- [x] Load an old `ExtensionBuilder.json` (pre-v10) and confirm no PHP warnings are thrown
- [x] Save an extension loaded from an old JSON and confirm it succeeds

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)