### PR TITLE
[FEATURE] Introduce Storybook for isolated Lit component development

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "env": {
         "browser": true,
-        "es6": true
+        "es2020": true
     },
     "globals": {
         "YAHOO": "readonly",

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -59,16 +59,21 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
 
+      - name: "Setup pnpm"
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
 
-      - name: "Run npm ci"
-        run: npm ci
+      - name: "Install dependencies"
+        run: pnpm install --frozen-lockfile
 
       - name: "Run ESLint"
-        run: npm run lint:js
+        run: pnpm run lint:js
 
   prettier:
     runs-on: ubuntu-latest
@@ -77,16 +82,21 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
 
+      - name: "Setup pnpm"
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
 
-      - name: "Run npm ci"
-        run: npm ci
+      - name: "Install dependencies"
+        run: pnpm install --frozen-lockfile
 
       - name: "Run Prettier format check"
-        run: npm run lint:format
+        run: pnpm run lint:format
 
   phpstan:
     runs-on: ubuntu-latest
@@ -117,13 +127,18 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
 
+      - name: "Setup pnpm"
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
 
-      - name: "Run npm ci"
-        run: npm ci
+      - name: "Install dependencies"
+        run: pnpm install --frozen-lockfile
 
-      - name: "Run npm sass-linter"
-        run: npm run lint:scss
+      - name: "Run sass-linter"
+        run: pnpm run lint:scss

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ CLAUDE.md
 Tests/E2E/.auth/
 playwright-report/
 test-results/
+
+# Storybook
+storybook-static/
 .playwright-cli
 .playwright-screenshots
 docs/superpowers

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,10 @@
+/** @type { import('@storybook/web-components-vite').StorybookConfig } */
+const config = {
+    stories: ['../Resources/Public/jsDomainModeling/src/**/*.stories.js'],
+    framework: {
+        name: '@storybook/web-components-vite',
+        options: {},
+    },
+};
+
+export default config;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,9 +1,27 @@
+import path from 'path';
+
 /** @type { import('@storybook/web-components-vite').StorybookConfig } */
 const config = {
     stories: ['../Resources/Public/jsDomainModeling/src/**/*.stories.js'],
     framework: {
         name: '@storybook/web-components-vite',
         options: {},
+    },
+    async viteFinal(viteConfig) {
+        const mocksDir = path.resolve(process.cwd(), '.storybook/mocks');
+
+        viteConfig.resolve = viteConfig.resolve ?? {};
+        // Use array form for Vite aliases — more reliable than object form
+        // for scoped package paths like @typo3/backend/notification.js
+        const existing = Array.isArray(viteConfig.resolve.alias) ? viteConfig.resolve.alias : [];
+        viteConfig.resolve.alias = [
+            ...existing,
+            { find: '@typo3/backend/notification.js', replacement: `${mocksDir}/typo3-notification.js` },
+            { find: '@typo3/backend/modal.js', replacement: `${mocksDir}/typo3-modal.js` },
+            { find: '@typo3/backend/severity.js', replacement: `${mocksDir}/typo3-severity.js` },
+        ];
+
+        return viteConfig;
     },
 };
 

--- a/.storybook/mocks/typo3-modal.js
+++ b/.storybook/mocks/typo3-modal.js
@@ -1,0 +1,15 @@
+// Storybook mock for @typo3/backend/modal.js
+const Modal = {
+    confirm: (title, content, severity, buttons) => {
+        // In Storybook use the native browser confirm as a stand-in
+        const ok = window.confirm(`[TYPO3 Modal] ${title}: ${content}`);
+        if (ok && buttons) {
+            const confirmBtn = buttons.find((b) => b.trigger);
+            confirmBtn?.trigger?.();
+        }
+    },
+    show: () => {},
+    dismiss: () => {},
+};
+
+export default Modal;

--- a/.storybook/mocks/typo3-notification.js
+++ b/.storybook/mocks/typo3-notification.js
@@ -1,0 +1,11 @@
+// Storybook mock for @typo3/backend/notification.js
+// In Storybook there is no TYPO3 backend, so we replace the notification API
+// with no-ops that log to the console instead.
+const Notification = {
+    info: (title, message) => console.info('[TYPO3 Notification] Info:', title, message),
+    success: (title, message) => console.info('[TYPO3 Notification] Success:', title, message),
+    warning: (title, message) => console.warn('[TYPO3 Notification] Warning:', title, message),
+    error: (title, message) => console.error('[TYPO3 Notification] Error:', title, message),
+};
+
+export default Notification;

--- a/.storybook/mocks/typo3-severity.js
+++ b/.storybook/mocks/typo3-severity.js
@@ -1,0 +1,10 @@
+// Storybook mock for @typo3/backend/severity.js
+const Severity = {
+    NOTICE: -2,
+    INFO: -1,
+    OK: 0,
+    WARNING: 1,
+    ERROR: 2,
+};
+
+export default Severity;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,22 @@
+// Mock window.TYPO3 for Storybook — translate() reads from
+// window.TYPO3.settings.extensionBuilder._LOCAL_LANG at runtime.
+// In Storybook there is no TYPO3 backend, so we provide an empty object;
+// translate() falls back to generating labels from camelCase keys automatically.
+window.TYPO3 = window.TYPO3 ?? {};
+window.TYPO3.settings = window.TYPO3.settings ?? {};
+window.TYPO3.settings.extensionBuilder = window.TYPO3.settings.extensionBuilder ?? {};
+window.TYPO3.settings.extensionBuilder._LOCAL_LANG = {};
+
+/** @type { import('@storybook/web-components').Preview } */
+const preview = {
+    parameters: {
+        controls: {
+            matchers: {
+                color: /(background|color)$/i,
+                date: /Date$/i,
+            },
+        },
+    },
+};
+
+export default preview;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,6 +7,57 @@ window.TYPO3.settings = window.TYPO3.settings ?? {};
 window.TYPO3.settings.extensionBuilder = window.TYPO3.settings.extensionBuilder ?? {};
 window.TYPO3.settings.extensionBuilder._LOCAL_LANG = {};
 
+// Inject TYPO3 backend CSS custom properties so components look identical to
+// their appearance inside the TYPO3 backend module. These are the same values
+// that the TYPO3 Bootstrap theme sets on :root in the backend.
+const style = document.createElement('style');
+style.textContent = `
+  :root {
+    /* Bootstrap base */
+    --bs-body-font-size: 0.875rem;
+    --bs-body-color: #333;
+    --bs-body-bg: #fff;
+    --bs-border-color: #c3c3c3;
+    --bs-border-radius: 0.25rem;
+    --bs-border-radius-sm: 0.2rem;
+    --bs-secondary-color: #6c757d;
+    --bs-secondary-bg: #e9ecef;
+    --bs-primary: #0d6efd;
+    --bs-danger: #dc3545;
+    --bs-warning: #ffc107;
+    --bs-dark: #212529;
+    --bs-box-shadow-sm: 2px 2px 6px rgba(0,0,0,.15);
+
+    /* TYPO3 brand */
+    --eb-brand-color: #ff8700;
+
+    /* TYPO3 module docheader */
+    --module-docheader-bg: #eee;
+    --module-docheader-border: #c3c3c3;
+    --module-docheader-padding-x: 24px;
+    --module-docheader-padding-y: 5px;
+
+    /* Terminal colors */
+    --eb-terminal-default: #4a90d9;
+    --eb-terminal-default-border: #2c5f8a;
+    --eb-terminal-input: #5cb85c;
+    --eb-terminal-input-border: #3d7a3d;
+    --eb-terminal-output: #d9534f;
+    --eb-terminal-output-border: #8a2c2c;
+    --eb-terminal-relation: #6ea8fe;
+    --eb-terminal-relation-border: #3d7bd4;
+
+    /* Wire color */
+    --eb-wire-color: #4a90d9;
+  }
+
+  /* Padding for story canvas */
+  .sb-show-main.sb-main-centered #storybook-root {
+    padding: 1.5rem;
+  }
+`;
+document.head.appendChild(style);
+
 /** @type { import('@storybook/web-components').Preview } */
 const preview = {
     parameters: {
@@ -16,6 +67,7 @@ const preview = {
                 date: /Date$/i,
             },
         },
+        layout: 'centered',
     },
 };
 

--- a/Resources/Public/jsDomainModeling/src/eb-boolean-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-boolean-field.stories.js
@@ -1,0 +1,43 @@
+import './eb-boolean-field.js';
+
+export default {
+    title: 'Form Fields/BooleanField',
+    component: 'eb-boolean-field',
+    tags: ['autodocs'],
+    argTypes: {
+        label: { control: 'text' },
+        value: { control: 'boolean' },
+        description: { control: 'text' },
+    },
+};
+
+const render = (args) => {
+    const el = document.createElement('eb-boolean-field');
+    if (args.label) {
+        el.setAttribute('label', args.label);
+    }
+    if (args.description) {
+        el.setAttribute('description', args.description);
+    }
+    el.value = Boolean(args.value);
+    return el;
+};
+
+export const Default = {
+    args: { label: 'Is Required', value: false },
+    render,
+};
+
+export const Checked = {
+    args: { label: 'Nullable', value: true },
+    render,
+};
+
+export const WithDescription = {
+    args: {
+        label: 'Exclude from AJAX save',
+        value: false,
+        description: 'When enabled, this field is excluded from AJAX save operations',
+    },
+    render,
+};

--- a/Resources/Public/jsDomainModeling/src/eb-container.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-container.stories.js
@@ -6,7 +6,7 @@ function makeModuleData(name, overrides = {}) {
         value: {
             name,
             objectsettings: {
-                uid: String(globalThis.crypto.getRandomValues(new Uint32Array(1))[0] % 1000),
+                uid: globalThis.crypto.randomUUID(),
                 type: 'Entity',
                 aggregateRoot: false,
                 addDeletedField: true,

--- a/Resources/Public/jsDomainModeling/src/eb-container.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-container.stories.js
@@ -1,0 +1,87 @@
+import './eb-container.js';
+
+// Minimal moduleData matching the shape eb-container reads from moduleData.value
+function makeModuleData(name, overrides = {}) {
+    return {
+        value: {
+            name,
+            objectsettings: {
+                uid: String(Math.floor(Math.random() * 1000)),
+                type: 'Entity',
+                aggregateRoot: false,
+                addDeletedField: true,
+                addHiddenField: true,
+                addStarttimeEndtimeField: false,
+                addCategorization: false,
+                addRecordType: false,
+            },
+            propertyGroup: { properties: [] },
+            actionGroup: { customActions: [], actions: [] },
+            ...overrides,
+        },
+    };
+}
+
+export default {
+    title: 'Canvas/Container',
+    component: 'eb-container',
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'padded',
+        docs: {
+            description: {
+                component:
+                    'Draggable domain model object card in the wiring canvas. Renders a colour-coded header with an `eb-terminal` output port and an inline-editable name, plus an auto-generated form body driven by the `modelObjectModule` config. Fires `container-moved`, `container-removed`, and `container-resized` events.',
+            },
+        },
+    },
+};
+
+export const Default = {
+    name: 'Domain model card',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.width = '360px';
+        wrapper.style.height = '600px';
+
+        const el = document.createElement('eb-container');
+        el.setAttribute('module-id', '1');
+        el.setAttribute('pos-x', '20');
+        el.setAttribute('pos-y', '20');
+        el.moduleData = makeModuleData('BlogPost');
+
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};
+
+export const ValueObject = {
+    name: 'Value Object card',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.width = '360px';
+        wrapper.style.height = '600px';
+
+        const el = document.createElement('eb-container');
+        el.setAttribute('module-id', '2');
+        el.setAttribute('pos-x', '20');
+        el.setAttribute('pos-y', '20');
+        el.moduleData = makeModuleData('Tag', {
+            objectsettings: {
+                uid: '99',
+                type: 'ValueObject',
+                aggregateRoot: false,
+                addDeletedField: false,
+                addHiddenField: false,
+                addStarttimeEndtimeField: false,
+                addCategorization: false,
+                addRecordType: false,
+            },
+        });
+
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-container.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-container.stories.js
@@ -6,7 +6,7 @@ function makeModuleData(name, overrides = {}) {
         value: {
             name,
             objectsettings: {
-                uid: String(Math.floor(Math.random() * 1000)),
+                uid: String(globalThis.crypto.getRandomValues(new Uint32Array(1))[0] % 1000),
                 type: 'Entity',
                 aggregateRoot: false,
                 addDeletedField: true,

--- a/Resources/Public/jsDomainModeling/src/eb-group.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-group.stories.js
@@ -1,0 +1,96 @@
+import './eb-group.js';
+import './eb-string-field.js';
+import './eb-boolean-field.js';
+import './eb-select-field.js';
+
+export default {
+    title: 'Layout/Group',
+    component: 'eb-group',
+    tags: ['autodocs'],
+    argTypes: {
+        legend: { control: 'text' },
+        collapsible: { control: 'boolean' },
+        collapsed: { control: 'boolean' },
+    },
+};
+
+export const Default = {
+    render: () => {
+        const group = document.createElement('eb-group');
+        group.setAttribute('legend', 'Object Settings');
+
+        const nameField = document.createElement('eb-string-field');
+        nameField.setAttribute('name', 'className');
+        nameField.setAttribute('label', 'Class Name');
+        nameField.setAttribute('uc-first', '');
+        nameField.setAttribute('required', '');
+        nameField.value = 'MyModel';
+
+        const typeSelect = document.createElement('eb-select-field');
+        typeSelect.setAttribute('name', 'type');
+        typeSelect.setAttribute('label', 'Object Type');
+        typeSelect.selectValues = ['Entity', 'ValueObject'];
+        typeSelect.value = 'Entity';
+
+        const aggregateRoot = document.createElement('eb-boolean-field');
+        aggregateRoot.setAttribute('name', 'aggregateRoot');
+        aggregateRoot.setAttribute('label', 'Aggregate Root');
+        aggregateRoot.value = true;
+
+        group.appendChild(nameField);
+        group.appendChild(typeSelect);
+        group.appendChild(aggregateRoot);
+
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '320px';
+        wrapper.appendChild(group);
+        return wrapper;
+    },
+};
+
+export const Collapsible = {
+    render: () => {
+        const group = document.createElement('eb-group');
+        group.setAttribute('legend', 'Advanced Settings');
+        group.setAttribute('collapsible', '');
+
+        const field1 = document.createElement('eb-boolean-field');
+        field1.setAttribute('name', 'addDeletedField');
+        field1.setAttribute('label', 'Add "deleted" field');
+        field1.value = false;
+
+        const field2 = document.createElement('eb-boolean-field');
+        field2.setAttribute('name', 'addHiddenField');
+        field2.setAttribute('label', 'Add "hidden" field');
+        field2.value = true;
+
+        group.appendChild(field1);
+        group.appendChild(field2);
+
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '320px';
+        wrapper.appendChild(group);
+        return wrapper;
+    },
+};
+
+export const CollapsedByDefault = {
+    render: () => {
+        const group = document.createElement('eb-group');
+        group.setAttribute('legend', 'Collapsed Section');
+        group.setAttribute('collapsible', '');
+        group.setAttribute('collapsed', '');
+
+        const field = document.createElement('eb-string-field');
+        field.setAttribute('name', 'description');
+        field.setAttribute('label', 'Description');
+        field.value = 'Hidden until expanded';
+
+        group.appendChild(field);
+
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '320px';
+        wrapper.appendChild(group);
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-hidden-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-hidden-field.stories.js
@@ -1,0 +1,44 @@
+import './eb-hidden-field.js';
+import './eb-string-field.js';
+
+export default {
+    title: 'Form Fields/HiddenField',
+    component: 'eb-hidden-field',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Hidden field that stores a value without rendering any visible UI. Used for internal state (e.g. uid) that participates in form serialisation. Shown here inside a group alongside a visible field.',
+            },
+        },
+    },
+};
+
+export const WithVisibleSibling = {
+    name: 'Hidden field inside a form group',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '320px';
+
+        const label = document.createElement('p');
+        label.style.fontSize = '0.75rem';
+        label.style.color = '#6c757d';
+        label.textContent =
+            'The uid field below is hidden (display: none). It stores the value "42" without rendering.';
+
+        const hiddenField = document.createElement('eb-hidden-field');
+        hiddenField.setAttribute('name', 'uid');
+        hiddenField.value = '42';
+
+        const visibleField = document.createElement('eb-string-field');
+        visibleField.setAttribute('name', 'propertyName');
+        visibleField.setAttribute('label', 'Property Name');
+        visibleField.value = 'title';
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(hiddenField);
+        wrapper.appendChild(visibleField);
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-inplace-edit.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-inplace-edit.stories.js
@@ -1,0 +1,49 @@
+import './eb-inplace-edit.js';
+
+export default {
+    title: 'Canvas/InplaceEdit',
+    component: 'eb-inplace-edit',
+    tags: ['autodocs'],
+    argTypes: {
+        value: { control: 'text' },
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Click-to-edit inline text. Renders as a dashed-underline span in display mode; switches to an input on click. Confirm with Enter or blur, cancel with Escape. Fires `inplace-change` on confirmation.',
+            },
+        },
+    },
+};
+
+const render = (args) => {
+    const wrapper = document.createElement('div');
+    wrapper.style.padding = '1rem';
+    wrapper.style.fontWeight = 'bold';
+    wrapper.style.fontSize = '1rem';
+
+    const el = document.createElement('eb-inplace-edit');
+    el.value = args.value ?? 'MyDomainObject';
+
+    // Storybook Actions panel picks up the custom event via the DOM event listener
+    el.addEventListener('inplace-change', () => {});
+
+    wrapper.appendChild(el);
+    return wrapper;
+};
+
+export const Default = {
+    args: { value: 'MyDomainObject' },
+    render,
+};
+
+export const EmptyValue = {
+    args: { value: '' },
+    render,
+};
+
+export const LongName = {
+    args: { value: 'AstronomicalObservationSession' },
+    render,
+};

--- a/Resources/Public/jsDomainModeling/src/eb-layer.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-layer.stories.js
@@ -1,0 +1,30 @@
+import './eb-layer.js';
+
+export default {
+    title: 'Canvas/Layer',
+    component: 'eb-layer',
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Canvas layer that hosts draggable `eb-container` cards and SVG `eb-wire` overlays. Manages pan offset and wire drawing via `terminal-connect` events. Programmatically populated via `setModules()` and `setWires()` — use `eb-wiring-editor` for the full integrated editor.',
+            },
+        },
+    },
+};
+
+export const EmptyCanvas = {
+    name: 'Empty canvas',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'position:fixed;inset:0;display:flex;flex-direction:column;border:1px solid #dee2e6;';
+
+        const el = document.createElement('eb-layer');
+        el.style.cssText = 'flex:1;min-height:0;';
+
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-list-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-list-field.stories.js
@@ -1,0 +1,96 @@
+import './eb-list-field.js';
+import './eb-group.js';
+import './eb-string-field.js';
+import './eb-boolean-field.js';
+import './eb-select-field.js';
+import './eb-hidden-field.js';
+
+// Minimal element type definition matching the property list format used in
+// the wiring editor. Each item gets a name field and a type selector.
+const propertyElementType = JSON.stringify({
+    inputParams: {
+        fields: [
+            {
+                inputParams: { name: 'uid', className: 'hiddenField' },
+            },
+            {
+                type: 'string',
+                inputParams: {
+                    name: 'propertyName',
+                    label: 'Property Name',
+                    required: true,
+                    'lc-first': true,
+                    'force-alpha-numeric-underscore': true,
+                },
+            },
+            {
+                type: 'select',
+                inputParams: {
+                    name: 'propertyType',
+                    label: 'Type',
+                    selectValues: ['string', 'integer', 'boolean', 'float', 'date', 'richText'],
+                },
+            },
+            {
+                type: 'boolean',
+                inputParams: {
+                    name: 'required',
+                    label: 'Required',
+                },
+            },
+        ],
+    },
+});
+
+export default {
+    title: 'Form Fields/ListField',
+    component: 'eb-list-field',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Sortable list of repeatable field groups. Each item can be collapsed, reordered, and deleted. The `element-type` attribute accepts a JSON definition that drives the field set rendered per item.',
+            },
+        },
+    },
+};
+
+export const Empty = {
+    name: 'Empty list',
+    render: () => {
+        const el = document.createElement('eb-list-field');
+        el.setAttribute('name', 'properties');
+        el.setAttribute('add-label', '+ Add Property');
+        el.setAttribute('element-type', propertyElementType);
+
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '380px';
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};
+
+export const WithItems = {
+    name: 'Pre-populated list',
+    render: () => {
+        const el = document.createElement('eb-list-field');
+        el.setAttribute('name', 'properties');
+        el.setAttribute('add-label', '+ Add Property');
+        el.setAttribute('element-type', propertyElementType);
+
+        const wrapper = document.createElement('div');
+        wrapper.style.width = '380px';
+        wrapper.appendChild(el);
+
+        // setValue after render cycle
+        requestAnimationFrame(() => {
+            el.setValue([
+                { uid: '1', propertyName: 'title', propertyType: 'string', required: true },
+                { uid: '2', propertyName: 'description', propertyType: 'richText', required: false },
+            ]);
+        });
+
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-select-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-select-field.stories.js
@@ -1,0 +1,53 @@
+import './eb-select-field.js';
+
+export default {
+    title: 'Form Fields/SelectField',
+    component: 'eb-select-field',
+    tags: ['autodocs'],
+    argTypes: {
+        label: { control: 'text' },
+        value: { control: 'text' },
+        required: { control: 'boolean' },
+        description: { control: 'text' },
+    },
+};
+
+const propertyTypes = ['string', 'integer', 'boolean', 'float', 'date', 'dateTime', 'richText', 'image', 'file'];
+
+const render = (args) => {
+    const el = document.createElement('eb-select-field');
+    if (args.label) {
+        el.setAttribute('label', args.label);
+    }
+    if (args.description) {
+        el.setAttribute('description', args.description);
+    }
+    if (args.required) {
+        el.setAttribute('required', '');
+    }
+    el.selectValues = propertyTypes;
+    el.value = args.value ?? propertyTypes[0];
+    return el;
+};
+
+export const Default = {
+    args: { label: 'Property Type', value: 'string' },
+    render,
+};
+
+export const WithDescription = {
+    args: { label: 'Relation Type', description: 'The type of relation between domain objects', value: 'integer' },
+    render,
+};
+
+export const WithAllowedValues = {
+    name: 'With Filtered Options',
+    render: () => {
+        const el = document.createElement('eb-select-field');
+        el.setAttribute('label', 'Filtered Type (only scalar)');
+        el.selectValues = propertyTypes;
+        el.allowedValues = ['string', 'integer', 'boolean', 'float'];
+        el.value = 'string';
+        return el;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-string-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-string-field.stories.js
@@ -1,0 +1,66 @@
+import './eb-string-field.js';
+
+export default {
+    title: 'Form Fields/StringField',
+    component: 'eb-string-field',
+    tags: ['autodocs'],
+    argTypes: {
+        value: { control: 'text' },
+        label: { control: 'text' },
+        required: { control: 'boolean' },
+        placeholder: { control: 'text' },
+        description: { control: 'text' },
+        'force-lower-case': { control: 'boolean' },
+        'uc-first': { control: 'boolean' },
+        'force-alpha-numeric-underscore': { control: 'boolean' },
+        'min-length': { control: 'number' },
+        'max-length': { control: 'number' },
+    },
+};
+
+const render = (args) => {
+    const el = document.createElement('eb-string-field');
+    Object.entries(args).forEach(([k, v]) => {
+        if (v === true) {
+            el.setAttribute(k, '');
+        } else if (v !== false && v !== undefined && v !== '') {
+            el.setAttribute(k, v);
+        }
+    });
+    return el;
+};
+
+export const Default = {
+    args: { label: 'Extension Name', value: 'my_extension', placeholder: 'my_extension' },
+    render,
+};
+
+export const Required = {
+    args: { label: 'Extension Key', required: true, 'force-lower-case': true, 'min-length': 3, 'max-length': 30 },
+    render,
+};
+
+export const WithDescription = {
+    args: {
+        label: 'Vendor Name',
+        description: 'Your PHP namespace vendor prefix',
+        value: 'MyVendor',
+        'uc-first': true,
+    },
+    render,
+};
+
+export const ForceAlphaNumericUnderscore = {
+    args: {
+        label: 'Table Name',
+        'force-alpha-numeric-underscore': true,
+        'force-lower-case': true,
+        value: 'tx_myext_domain_model_item',
+    },
+    render,
+};
+
+export const ValidationError = {
+    args: { label: 'Class Name', required: true, 'uc-first': true, value: '', 'min-length': 3 },
+    render,
+};

--- a/Resources/Public/jsDomainModeling/src/eb-terminal.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-terminal.stories.js
@@ -1,0 +1,79 @@
+import './eb-terminal.js';
+
+export default {
+    title: 'Canvas/Terminal',
+    component: 'eb-terminal',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Visual connection point (port) on a domain model container card. Clicking fires `terminal-connect` so `eb-layer` can draw a wire. The `type` attribute controls color and meaning: `input` (green) = accepts a relation, `output` (red) = exposes a relation. Droppable terminals (blue) are rendered inline in relation list items.',
+            },
+        },
+    },
+};
+
+export const Input = {
+    name: 'Input terminal (green)',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.width = '80px';
+        wrapper.style.height = '30px';
+
+        const el = document.createElement('eb-terminal');
+        el.setAttribute('type', 'input');
+        el.setAttribute('terminal-id', 'TERM_in');
+        el.setAttribute('uid', '1');
+        el.style.position = 'relative';
+        el.style.display = 'inline-block';
+
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};
+
+export const Output = {
+    name: 'Output terminal (red)',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.width = '80px';
+        wrapper.style.height = '30px';
+
+        const el = document.createElement('eb-terminal');
+        el.setAttribute('type', 'output');
+        el.setAttribute('terminal-id', 'TERM_out');
+        el.setAttribute('uid', '1');
+        el.style.position = 'relative';
+        el.style.display = 'inline-block';
+
+        wrapper.appendChild(el);
+        return wrapper;
+    },
+};
+
+export const Droppable = {
+    name: 'Droppable terminal (blue, inline in list)',
+    render: () => {
+        const wrapper = document.createElement('div');
+        wrapper.style.display = 'flex';
+        wrapper.style.alignItems = 'center';
+        wrapper.style.gap = '8px';
+        wrapper.style.padding = '8px';
+
+        const el = document.createElement('eb-terminal');
+        el.setAttribute('droppable', '');
+        el.setAttribute('terminal-id', 'REL_0');
+        el.setAttribute('uid', '42');
+
+        const label = document.createElement('span');
+        label.style.fontSize = '0.75rem';
+        label.textContent = 'Drop relation here';
+
+        wrapper.appendChild(el);
+        wrapper.appendChild(label);
+        return wrapper;
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-textarea-field.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-textarea-field.stories.js
@@ -1,0 +1,52 @@
+import './eb-textarea-field.js';
+
+export default {
+    title: 'Form Fields/TextareaField',
+    component: 'eb-textarea-field',
+    tags: ['autodocs'],
+    argTypes: {
+        label: { control: 'text' },
+        value: { control: 'text' },
+        rows: { control: 'number' },
+        description: { control: 'text' },
+    },
+};
+
+const render = (args) => {
+    const el = document.createElement('eb-textarea-field');
+    if (args.label) {
+        el.setAttribute('label', args.label);
+    }
+    if (args.description) {
+        el.setAttribute('description', args.description);
+    }
+    if (args.rows) {
+        el.setAttribute('rows', args.rows);
+    }
+    el.value = args.value ?? '';
+    return el;
+};
+
+export const Default = {
+    args: { label: 'Description', value: '', rows: 4 },
+    render,
+};
+
+export const WithContent = {
+    args: {
+        label: 'Extension Description',
+        value: 'This extension provides a custom domain model for managing astrophotography data including telescopes, cameras, and observation sessions.',
+        rows: 4,
+    },
+    render,
+};
+
+export const WithDescription = {
+    args: {
+        label: 'Notes',
+        description: 'Additional notes visible in the backend list view',
+        value: '',
+        rows: 3,
+    },
+    render,
+};

--- a/Resources/Public/jsDomainModeling/src/eb-wire.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-wire.stories.js
@@ -1,0 +1,80 @@
+import './eb-wire.js';
+
+export default {
+    title: 'Canvas/Wire',
+    component: 'eb-wire',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'SVG cubic Bézier curve connecting two terminals on the canvas. Must be rendered inside an `<svg>` element. Coordinates are in `eb-layer` canvas space.',
+            },
+        },
+    },
+};
+
+function makeSvg(width, height, ...wires) {
+    const wrapper = document.createElement('div');
+    wrapper.style.width = `${width}px`;
+    wrapper.style.height = `${height}px`;
+    wrapper.style.border = '1px solid #dee2e6';
+    wrapper.style.borderRadius = '4px';
+    wrapper.style.background = '#f8f9fa';
+    wrapper.style.position = 'relative';
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', width);
+    svg.setAttribute('height', height);
+    svg.style.position = 'absolute';
+    svg.style.top = '0';
+    svg.style.left = '0';
+
+    wires.forEach((wire) => svg.appendChild(wire));
+    wrapper.appendChild(svg);
+    return wrapper;
+}
+
+export const StraightDown = {
+    name: 'Vertical wire',
+    render: () => {
+        const wire = document.createElement('eb-wire');
+        wire.setAttribute('x1', '150');
+        wire.setAttribute('y1', '20');
+        wire.setAttribute('x2', '150');
+        wire.setAttribute('y2', '180');
+        return makeSvg(300, 200, wire);
+    },
+};
+
+export const DiagonalWire = {
+    name: 'Diagonal wire',
+    render: () => {
+        const wire = document.createElement('eb-wire');
+        wire.setAttribute('x1', '50');
+        wire.setAttribute('y1', '30');
+        wire.setAttribute('x2', '250');
+        wire.setAttribute('y2', '170');
+        return makeSvg(300, 200, wire);
+    },
+};
+
+export const MultipleWires = {
+    name: 'Multiple wires',
+    render: () => {
+        const wire1 = document.createElement('eb-wire');
+        wire1.setAttribute('x1', '80');
+        wire1.setAttribute('y1', '20');
+        wire1.setAttribute('x2', '220');
+        wire1.setAttribute('y2', '180');
+
+        const wire2 = document.createElement('eb-wire');
+        wire2.setAttribute('x1', '220');
+        wire2.setAttribute('y1', '20');
+        wire2.setAttribute('x2', '80');
+        wire2.setAttribute('y2', '180');
+        wire2.style.setProperty('--eb-wire-color', '#ff8700');
+
+        return makeSvg(300, 200, wire1, wire2);
+    },
+};

--- a/Resources/Public/jsDomainModeling/src/eb-wiring-editor.stories.js
+++ b/Resources/Public/jsDomainModeling/src/eb-wiring-editor.stories.js
@@ -1,0 +1,38 @@
+import './eb-wiring-editor.js';
+
+export default {
+    title: 'Canvas/WiringEditor',
+    component: 'eb-wiring-editor',
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Top-level wiring editor component. Orchestrates loading, saving, and resetting extension data via the SMD JSON-RPC endpoint. Renders the toolbar, a collapsible left panel with extension properties, and the central `eb-layer` canvas. In Storybook: TYPO3 backend APIs (Notification, Modal, Severity) are mocked. The SMD endpoint is not available, so load/save operations will fail gracefully.',
+            },
+        },
+    },
+    decorators: [
+        // eb-wiring-editor is a flex column that needs a defined height on its
+        // parent to expand correctly. This decorator stretches the story root to
+        // the full viewport so the inner canvas fills the available space.
+        (story) => {
+            const wrapper = document.createElement('div');
+            wrapper.style.cssText = 'position:fixed;inset:0;display:flex;flex-direction:column;';
+            wrapper.appendChild(story());
+            return wrapper;
+        },
+    ],
+};
+
+export const Standalone = {
+    name: 'Editor (no backend)',
+    render: () => {
+        const el = document.createElement('eb-wiring-editor');
+        // smd-url intentionally omitted — no backend available in Storybook.
+        // The editor renders its full UI shell; load/save will fail gracefully.
+        el.style.cssText = 'flex:1;min-height:0;width:100%;';
+        return el;
+    },
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
         "lint:fix": "prettier --write 'Resources/Public/jsDomainModeling/**/*.{js,css}' && eslint Resources/Public/jsDomainModeling/**/*.js --fix",
         "test:e2e": "playwright test",
         "test:e2e:ui": "playwright test --ui",
-        "test:e2e:headed": "playwright test --headed"
+        "test:e2e:headed": "playwright test --headed",
+        "storybook": "storybook dev -p 6006",
+        "build-storybook": "storybook build"
     },
     "dependencies": {
         "lit": "^3.2.0"
@@ -22,9 +24,11 @@
     "license": "GPL-2.0-or-later",
     "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@storybook/web-components-vite": "^10.3.5",
         "@types/node": "^20.19.39",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
+        "storybook": "^10.3.5",
         "stylelint": "^16.9.0",
         "stylelint-config-standard": "^36.0.0",
         "vite": "^5.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.59.1
+      '@storybook/web-components-vite':
+        specifier: ^10.3.5
+        version: 10.3.5(esbuild@0.21.5)(lit@3.3.2)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))
       '@types/node':
         specifier: ^20.19.39
         version: 20.19.39
@@ -24,6 +27,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.8.1
+      storybook:
+        specifier: ^10.3.5
+        version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       stylelint:
         specifier: ^16.9.0
         version: 16.26.1
@@ -36,12 +42,19 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@cacheable/memory@2.0.8':
@@ -253,6 +266,22 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@keyv/bigmap@1.3.1':
     resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
     engines: {node: '>= 18'}
@@ -423,6 +452,73 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@storybook/builder-vite@10.3.5':
+    resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
+    peerDependencies:
+      storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.3.5':
+    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.5
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.1':
+    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/web-components-vite@10.3.5':
+    resolution: {integrity: sha512-6uAw6KAUXFsAPzp8KchcMp3gatEnEAd8ylIvzoMzvsIMiHmzXwvDNmoFZnAJ2tmsQGvF4dZRDCBg7PvWdTx8Rg==}
+    peerDependencies:
+      storybook: ^10.3.5
+
+  '@storybook/web-components@10.3.5':
+    resolution: {integrity: sha512-tSppZagFCeZ+bWsaHUvdiw17ATWgfGDBz0mFicgEj0/eNuxQH2OvXyRIQUXY39b/55TBwSGeoIX3tOW91WIqpw==}
+    peerDependencies:
+      lit: ^2.0.0 || ^3.0.0
+      storybook: ^10.3.5
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -434,6 +530,21 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -459,12 +570,31 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -483,6 +613,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   cacheable@2.3.4:
     resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
 
@@ -490,9 +624,17 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -528,6 +670,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -542,8 +687,28 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -552,6 +717,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -589,6 +760,11 @@ packages:
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -735,6 +911,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -748,6 +928,11 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -760,6 +945,11 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -771,6 +961,10 @@ packages:
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -836,6 +1030,13 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
@@ -853,6 +1054,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -874,6 +1079,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -911,12 +1120,20 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -957,6 +1174,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -967,6 +1188,26 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -994,8 +1235,20 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1021,12 +1274,29 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  storybook@10.3.5:
+    resolution: {integrity: sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
@@ -1068,9 +1338,27 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1083,8 +1371,17 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1120,6 +1417,9 @@ packages:
       terser:
         optional: true
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -1140,11 +1440,29 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1153,6 +1471,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@cacheable/memory@2.0.8':
     dependencies:
@@ -1291,6 +1611,25 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
       hashery: 1.5.1
@@ -1396,6 +1735,86 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@storybook/builder-vite@10.3.5(esbuild@0.21.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.21.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.3.5(esbuild@0.21.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.21.5
+      rollup: 4.60.1
+      vite: 5.4.21(@types/node@20.19.39)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@storybook/web-components-vite@10.3.5(esbuild@0.21.5)(lit@3.3.2)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@storybook/builder-vite': 10.3.5(esbuild@0.21.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@5.4.21(@types/node@20.19.39))
+      '@storybook/web-components': 10.3.5(lit@3.3.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - esbuild
+      - lit
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/web-components@10.3.5(lit@3.3.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      lit: 3.3.2
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@20.19.39':
@@ -1405,6 +1824,30 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@webcontainer/env@1.1.1': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -1432,9 +1875,23 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
 
   astral-regex@2.0.0: {}
 
@@ -1451,6 +1908,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   cacheable@2.3.4:
     dependencies:
       '@cacheable/memory': 2.0.8
@@ -1461,10 +1922,20 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1496,13 +1967,28 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  dequal@2.0.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -1511,6 +1997,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -1603,6 +2093,8 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 3.4.3
+
+  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -1744,6 +2236,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -1755,6 +2249,8 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -1763,11 +2259,19 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
 
   is-plain-object@5.0.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -1830,6 +2334,10 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  loupe@3.2.1: {}
+
+  lz-string@1.5.0: {}
+
   mathml-tag-names@2.1.3: {}
 
   mdn-data@2.27.1: {}
@@ -1842,6 +2350,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.5:
     dependencies:
@@ -1858,6 +2368,13 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -1895,9 +2412,13 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
 
   playwright-core@1.59.1: {}
 
@@ -1930,6 +2451,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
 
   qified@0.9.1:
@@ -1937,6 +2464,28 @@ snapshots:
       hookified: 2.1.1
 
   queue-microtask@1.2.3: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.5: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
 
@@ -1981,9 +2530,15 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  scheduler@0.27.0: {}
+
+  semver@7.7.4: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2003,6 +2558,32 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
+  storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.21.5
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.1
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -2012,6 +2593,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 
@@ -2090,9 +2675,19 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  tiny-invariant@1.3.3: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  ts-dedent@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -2102,9 +2697,20 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 
@@ -2116,6 +2722,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       fsevents: 2.3.3
+
+  webpack-virtual-modules@0.6.2: {}
 
   which@1.3.1:
     dependencies:
@@ -2133,5 +2741,11 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
## Summary

- Introduces Storybook 10.x (`@storybook/web-components-vite`) for isolated development and documentation of all Lit components
- Adds stories for all 14 components across three categories: Form Fields, Layout, and Canvas
- Mocks TYPO3 backend APIs (`@typo3/backend/*`) via Vite aliases so `eb-wiring-editor` renders in Storybook without a TYPO3 backend
- Injects TYPO3 CSS custom properties in `preview.js` so components look identical to their appearance in the TYPO3 backend module

## Components with stories

| Category | Component | Stories |
|----------|-----------|---------|
| Form Fields | `eb-string-field` | Default, Required, WithDescription, ForceAlphaNumericUnderscore, ValidationError |
| | `eb-boolean-field` | Default, Checked, WithDescription |
| | `eb-select-field` | Default, WithDescription, WithAllowedValues |
| | `eb-textarea-field` | Default, WithContent, WithDescription |
| | `eb-hidden-field` | WithVisibleSibling |
| | `eb-list-field` | Empty, Pre-populated |
| Layout | `eb-group` | Default, Collapsible, CollapsedByDefault |
| Canvas | `eb-inplace-edit` | Default, EmptyValue, LongName |
| | `eb-terminal` | Input, Output, Droppable |
| | `eb-wire` | Vertical, Diagonal, Multiple |
| | `eb-container` | Domain model card, Value Object card |
| | `eb-layer` | Empty canvas (fullscreen) |
| | `eb-wiring-editor` | Editor (no backend, fullscreen) |

## Run Storybook

```bash
pnpm storybook
# → http://localhost:6006
```

## Test plan

- [ ] Run `pnpm storybook` and verify all stories render without errors
- [ ] Check Form Fields category: string, boolean, select, textarea, hidden, list fields all render with correct Bootstrap-style appearance
- [ ] Check Canvas/WiringEditor story: full editor UI with toolbar and extension properties panel fills the viewport height
- [ ] Verify Controls panel in Storybook sidebar shows component properties for each story
- [ ] Run `pnpm lint` — no new errors (4 pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)