### PR TITLE
[BUGFIX] #680: Update composer.json on each save and include author email/company

### DIFF
--- a/Classes/Domain/Model/Extension.php
+++ b/Classes/Domain/Model/Extension.php
@@ -702,6 +702,12 @@ class Extension
             if ($person->getRole() !== '') {
                 $author['role'] = $person->getRole();
             }
+            if ($person->getEmail() !== '') {
+                $author['email'] = $person->getEmail();
+            }
+            if ($person->getCompany() !== '') {
+                $author['homepage'] = $person->getCompany();
+            }
             $info['authors'][] = $author;
         }
         return $info;

--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -160,7 +160,9 @@ class FileGenerator
 
         $this->configurationDirectory = $this->extensionDirectory . 'Configuration/';
 
-        mkdir($this->extensionDirectory . 'Resources/Private', 0777, true);
+        if (!is_dir($this->extensionDirectory . 'Resources/Private')) {
+            mkdir($this->extensionDirectory . 'Resources/Private', 0777, true);
+        }
 
         $this->privateResourcesDirectory = $this->extensionDirectory . 'Resources/Private/';
 

--- a/Classes/Service/FileGenerator.php
+++ b/Classes/Service/FileGenerator.php
@@ -1122,19 +1122,32 @@ class FileGenerator
     }
 
     /**
-     * create a basic composer file (only if none exists)
+     * Create or update the composer.json file.
+     *
+     * On first creation, the full generated structure is written.
+     * On subsequent saves, only EB-controlled fields (name, description, authors)
+     * are updated — any manual additions (require, scripts, config, etc.) are preserved.
      *
      * @throws Exception
      */
     public function generateComposerJson(): void
     {
-        if (!file_exists($this->extensionDirectory . 'composer.json')) {
-            $composerInfo = $this->extension->getComposerInfo();
-            $this->writeFile(
-                $this->extension->getExtensionDir() . 'composer.json',
-                json_encode($composerInfo, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
-            );
+        $composerFile = $this->extensionDirectory . 'composer.json';
+        $newInfo = $this->extension->getComposerInfo();
+
+        if (file_exists($composerFile)) {
+            $existing = json_decode((string)file_get_contents($composerFile), true) ?? [];
+            $newInfo = array_merge($existing, [
+                'name'        => $newInfo['name'],
+                'description' => $newInfo['description'],
+                'authors'     => $newInfo['authors'],
+            ]);
         }
+
+        $this->writeFile(
+            $this->extension->getExtensionDir() . 'composer.json',
+            json_encode($newInfo, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+        );
     }
 
     /**

--- a/Tests/Fixtures/TestExtensions/test_extension/composer.json
+++ b/Tests/Fixtures/TestExtensions/test_extension/composer.json
@@ -5,7 +5,9 @@
 	"authors": [
 		{
 			"name": "John Doe",
-			"role": "Developer"
+			"role": "Developer",
+			"email": "mail@typo3.com",
+			"homepage": "TYPO3"
 		}
 	],
 	"license": "GPL-2.0-or-later",

--- a/Tests/Functional/Service/FileGeneratorTest.php
+++ b/Tests/Functional/Service/FileGeneratorTest.php
@@ -22,6 +22,7 @@ use EBT\ExtensionBuilder\Domain\Model\DomainObject\Action;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\BooleanProperty;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\Relation;
 use EBT\ExtensionBuilder\Domain\Model\DomainObject\StringProperty;
+use EBT\ExtensionBuilder\Domain\Model\Person;
 use EBT\ExtensionBuilder\Domain\Model\Plugin;
 use EBT\ExtensionBuilder\Tests\BaseFunctionalTest;
 use EBT\ExtensionBuilder\Utility\Inflector;
@@ -663,5 +664,76 @@ class FileGeneratorTest extends BaseFunctionalTest
 
         self::assertFileExists($extensionDir . 'Configuration/TypoScript/setup.' . $deprecatedExtension);
         self::assertFileDoesNotExist($extensionDir . 'Configuration/TypoScript/setup.typoscript');
+    }
+
+    /**
+     * @test
+     */
+    public function generateComposerJsonWritesAuthorEmailOnFirstBuild(): void
+    {
+        $person = (new Person())->setName('John Doe')->setEmail('john@example.com')->setRole('developer');
+        $this->extension->setPersons([$person]);
+
+        $this->fileGenerator->build($this->extension);
+
+        $composerFile = $this->extension->getExtensionDir() . 'composer.json';
+        self::assertFileExists($composerFile);
+
+        $data = json_decode(file_get_contents($composerFile), true);
+        self::assertSame('John Doe', $data['authors'][0]['name']);
+        self::assertSame('john@example.com', $data['authors'][0]['email']);
+        self::assertSame('developer', $data['authors'][0]['role']);
+    }
+
+    /**
+     * @test
+     */
+    public function generateComposerJsonWritesAllAuthors(): void
+    {
+        $person1 = (new Person())->setName('Alice')->setEmail('alice@example.com');
+        $person2 = (new Person())->setName('Bob')->setEmail('bob@example.com');
+        $this->extension->setPersons([$person1, $person2]);
+
+        $this->fileGenerator->build($this->extension);
+
+        $data = json_decode(file_get_contents($this->extension->getExtensionDir() . 'composer.json'), true);
+        self::assertCount(2, $data['authors']);
+        self::assertSame('Alice', $data['authors'][0]['name']);
+        self::assertSame('alice@example.com', $data['authors'][0]['email']);
+        self::assertSame('Bob', $data['authors'][1]['name']);
+        self::assertSame('bob@example.com', $data['authors'][1]['email']);
+    }
+
+    /**
+     * @test
+     */
+    public function generateComposerJsonUpdatesAuthorsOnRebuildWithoutOverwritingManualRequire(): void
+    {
+        // First build: creates composer.json
+        $person = (new Person())->setName('Original Author')->setEmail('original@example.com');
+        $this->extension->setPersons([$person]);
+        $this->fileGenerator->build($this->extension);
+
+        // Simulate developer adding a manual require entry
+        $composerFile = $this->extension->getExtensionDir() . 'composer.json';
+        $data = json_decode(file_get_contents($composerFile), true);
+        $data['require']['vendor/some-package'] = '^1.0';
+        file_put_contents($composerFile, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+        // Second build: add a new author
+        $person2 = (new Person())->setName('New Author')->setEmail('new@example.com');
+        $this->extension->setPersons([$person, $person2]);
+        $this->fileGenerator->build($this->extension);
+
+        $updated = json_decode(file_get_contents($composerFile), true);
+
+        // Authors are updated
+        self::assertCount(2, $updated['authors']);
+        self::assertSame('Original Author', $updated['authors'][0]['name']);
+        self::assertSame('New Author', $updated['authors'][1]['name']);
+
+        // Manually added require is preserved
+        self::assertArrayHasKey('vendor/some-package', $updated['require']);
+        self::assertSame('^1.0', $updated['require']['vendor/some-package']);
     }
 }

--- a/Tests/Unit/Domain/Model/ExtensionTest.php
+++ b/Tests/Unit/Domain/Model/ExtensionTest.php
@@ -142,4 +142,70 @@ class ExtensionTest extends BaseUnitTest
 
         self::assertArrayHasKey('php', $composerInfo['require']);
     }
+
+    /**
+     * @test
+     */
+    public function getComposerInfoIncludesAuthorEmailWhenSet(): void
+    {
+        $this->extension->setExtensionKey('test_extension');
+        $this->extension->setVendorName('TestVendor');
+        $person = (new Person())->setName('John Doe')->setEmail('john@example.com');
+        $this->extension->setPersons([$person]);
+
+        $composerInfo = $this->extension->getComposerInfo();
+
+        self::assertSame('John Doe', $composerInfo['authors'][0]['name']);
+        self::assertSame('john@example.com', $composerInfo['authors'][0]['email']);
+    }
+
+    /**
+     * @test
+     */
+    public function getComposerInfoOmitsEmailKeyWhenEmpty(): void
+    {
+        $this->extension->setExtensionKey('test_extension');
+        $this->extension->setVendorName('TestVendor');
+        $person = (new Person())->setName('Jane Doe');
+        $this->extension->setPersons([$person]);
+
+        $composerInfo = $this->extension->getComposerInfo();
+
+        self::assertArrayNotHasKey('email', $composerInfo['authors'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function getComposerInfoIncludesHomepageFromCompanyWhenSet(): void
+    {
+        $this->extension->setExtensionKey('test_extension');
+        $this->extension->setVendorName('TestVendor');
+        $person = (new Person())->setName('Jane Doe')->setCompany('https://example.com');
+        $this->extension->setPersons([$person]);
+
+        $composerInfo = $this->extension->getComposerInfo();
+
+        self::assertSame('https://example.com', $composerInfo['authors'][0]['homepage']);
+    }
+
+    /**
+     * @test
+     */
+    public function getComposerInfoIncludesAllAuthors(): void
+    {
+        $this->extension->setExtensionKey('test_extension');
+        $this->extension->setVendorName('TestVendor');
+        $person1 = (new Person())->setName('Alice')->setEmail('alice@example.com');
+        $person2 = (new Person())->setName('Bob')->setEmail('bob@example.com');
+        $this->extension->setPersons([$person1, $person2]);
+
+        $composerInfo = $this->extension->getComposerInfo();
+
+        self::assertCount(2, $composerInfo['authors']);
+        self::assertSame('Alice', $composerInfo['authors'][0]['name']);
+        self::assertSame('alice@example.com', $composerInfo['authors'][0]['email']);
+        self::assertSame('Bob', $composerInfo['authors'][1]['name']);
+        self::assertSame('bob@example.com', $composerInfo['authors'][1]['email']);
+    }
 }


### PR DESCRIPTION
## Summary

- `Extension::getComposerInfo()` now includes `email` and `homepage` (from company field) for each author — matching what `ext_emconf.php` already writes
- `FileGenerator::generateComposerJson()` now updates `composer.json` on every save instead of only on first creation. Only EB-controlled fields (`name`, `description`, `authors`) are overwritten; any manually added fields (`require`, `scripts`, `config`, etc.) are preserved via a merge strategy
- Unit tests for all author field combinations (`email`, `homepage`, multiple authors)
- Functional tests for first-creation and roundtrip-update behaviour

## Test plan

- [x] Unit tests: `Tests/Unit/Domain/Model/ExtensionTest.php` — all new `getComposerInfo` author tests pass
- [x] Functional tests: `Tests/Functional/Service/FileGeneratorTest.php` — new `generateComposerJson*` tests verify first-build and roundtrip behaviour
- [x] Manual: Create a new extension with author + email → check `composer.json` contains email
- [x] Manual: Open existing extension, add a second author, save again → both authors appear in `composer.json`, custom `require` entries unchanged

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)